### PR TITLE
Add score keeping for both players

### DIFF
--- a/Assets/Prefabs/vertical_wall.prefab
+++ b/Assets/Prefabs/vertical_wall.prefab
@@ -10,8 +10,9 @@ GameObject:
   m_Component:
   - component: {fileID: 5033810390720941941}
   - component: {fileID: 5033810390720941942}
+  - component: {fileID: 8265823928639975322}
   m_Layer: 0
-  m_Name: wall_left
+  m_Name: vertical_wall
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -80,3 +81,29 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &8265823928639975322
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5033810390720941943}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 32}
+    newSize: {x: 0.01, y: 0.32}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 32}
+  m_EdgeRadius: 0

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -185,7 +185,7 @@ PrefabInstance:
     - target: {fileID: 5033810390720941943, guid: d6b912f211fa2f84da91ca642de1df7f,
         type: 3}
       propertyPath: m_Name
-      value: left_wall
+      value: LeftWall
       objectReference: {fileID: 0}
     - target: {fileID: 5033810390720941943, guid: d6b912f211fa2f84da91ca642de1df7f,
         type: 3}
@@ -348,7 +348,7 @@ PrefabInstance:
     - target: {fileID: 2066982697507942058, guid: 4bbb6c098bbf97543bf387577c75cf1c,
         type: 3}
       propertyPath: m_Name
-      value: mid_line
+      value: MidLine
       objectReference: {fileID: 0}
     - target: {fileID: 2066982697507942058, guid: 4bbb6c098bbf97543bf387577c75cf1c,
         type: 3}
@@ -373,7 +373,7 @@ PrefabInstance:
     - target: {fileID: 6591668963266348511, guid: bab790aa261a1694fa25e6e90b36d9a5,
         type: 3}
       propertyPath: m_Name
-      value: bottom_wall
+      value: BottomWall
       objectReference: {fileID: 0}
     - target: {fileID: 6591668963266348511, guid: bab790aa261a1694fa25e6e90b36d9a5,
         type: 3}
@@ -508,7 +508,7 @@ PrefabInstance:
     - target: {fileID: 5033810390720941943, guid: d6b912f211fa2f84da91ca642de1df7f,
         type: 3}
       propertyPath: m_Name
-      value: right_wall
+      value: RightWall
       objectReference: {fileID: 0}
     - target: {fileID: 5033810390720941943, guid: d6b912f211fa2f84da91ca642de1df7f,
         type: 3}
@@ -541,7 +541,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d08e6e93e462d54c831f2f23873b9fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moveSpeed: 30
+  paddleName: RightPaddle
+  paddleSpeed: 30
+  score: 0
 --- !u!1001 &871942651
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -552,7 +554,7 @@ PrefabInstance:
     - target: {fileID: 6591668963266348511, guid: bab790aa261a1694fa25e6e90b36d9a5,
         type: 3}
       propertyPath: m_Name
-      value: top_wall
+      value: TopWall
       objectReference: {fileID: 0}
     - target: {fileID: 6591668963266348511, guid: bab790aa261a1694fa25e6e90b36d9a5,
         type: 3}
@@ -675,8 +677,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 166a20cd2a9d4f840ada04bd0fd97a9a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moveSpeed: 30
+  paddleName: LeftPaddle
+  paddleSpeed: 30
   inputAxisName: Vertical
+  score: 0
 --- !u!1001 &1438342285
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -764,6 +768,11 @@ PrefabInstance:
       propertyPath: initialDirection.x
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7617027791629370975, guid: c8dbfa0f129a8e84e951632cab7d6425,
+        type: 3}
+      propertyPath: ballSpeed
+      value: 30
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c8dbfa0f129a8e84e951632cab7d6425, type: 3}
 --- !u!1001 &1974708889
@@ -846,7 +855,7 @@ PrefabInstance:
     - target: {fileID: 8734476180867663125, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_Name
-      value: PlayerPaddle
+      value: LeftPaddle
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff, type: 3}
@@ -930,7 +939,7 @@ PrefabInstance:
     - target: {fileID: 8734476180867663125, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_Name
-      value: AiPaddle
+      value: RightPaddle
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff, type: 3}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -820,7 +820,7 @@ PrefabInstance:
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
@@ -904,7 +904,7 @@ PrefabInstance:
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}

--- a/Assets/Scripts/AiController.cs
+++ b/Assets/Scripts/AiController.cs
@@ -14,6 +14,7 @@ public class AiController : MonoBehaviour
         paddle = GameObject.Find("AiPaddle").GetComponent<Rigidbody2D>();
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
     }
+
     void FixedUpdate()
     {
         Vector2 current = paddle.position;

--- a/Assets/Scripts/AiController.cs
+++ b/Assets/Scripts/AiController.cs
@@ -3,12 +3,14 @@
 public class AiController : MonoBehaviour
 {
     public float moveSpeed;
-    
+
+    private int score;
     private Rigidbody2D paddle;
     private Rigidbody2D ball;
 
     void Start()
     {
+        score = 0;
         paddle = GameObject.Find("AiPaddle").GetComponent<Rigidbody2D>();
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
     }

--- a/Assets/Scripts/AiController.cs
+++ b/Assets/Scripts/AiController.cs
@@ -2,16 +2,18 @@
 
 public class AiController : MonoBehaviour
 {
-    public float moveSpeed;
+    public string paddleName;
+    public float paddleSpeed;
 
-    private int score;
+    [HideInInspector] public int score;
+
     private Rigidbody2D paddle;
     private Rigidbody2D ball;
 
     void Start()
     {
         score = 0;
-        paddle = GameObject.Find("AiPaddle").GetComponent<Rigidbody2D>();
+        paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
     }
 
@@ -19,6 +21,6 @@ public class AiController : MonoBehaviour
     {
         Vector2 current = paddle.position;
         Vector2 target = new Vector2(current.x, ball.position.y);
-        paddle.position = Vector2.MoveTowards(current, target, moveSpeed * Time.deltaTime);
+        paddle.position = Vector2.MoveTowards(current, target, paddleSpeed * Time.deltaTime);
     }
 }

--- a/Assets/Scripts/BallController.cs
+++ b/Assets/Scripts/BallController.cs
@@ -7,6 +7,7 @@ public class BallController : MonoBehaviour
 
     private Rigidbody2D ball;
 
+
     void Start()
     {
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
@@ -19,6 +20,15 @@ public class BallController : MonoBehaviour
         if (collision.gameObject.CompareTag("Paddle"))
         {
             ball.velocity = ballSpeed * ComputeBounceDirection(ball.position, collision.rigidbody.position, collision.collider);
+        }
+        // really, really bad, but will be replaced by a proper event system for scoring during next refactoring day!
+        else if (collision.gameObject.name == "LeftWall")
+        {
+            GameObject.Find("RightPaddle").GetComponent<AiController>().score += 1;
+        }
+        else if (collision.gameObject.name == "RightWall")
+        {
+            GameObject.Find("LeftPaddle").GetComponent<PlayerController>().score += 1;
         }
     }
     private Vector2 ComputeBounceDirection(Vector2 ballPosition, Vector2 paddlePosition, Collider2D paddleCollider)

--- a/Assets/Scripts/BallController.cs
+++ b/Assets/Scripts/BallController.cs
@@ -2,15 +2,15 @@
 
 public class BallController : MonoBehaviour
 {
-    public float moveSpeed;
+    public float ballSpeed;
     public Vector2 initialDirection;
 
     private Rigidbody2D ball;
 
     void Start()
     {
-        ball = GetComponent<Rigidbody2D>();
-        ball.velocity = moveSpeed * initialDirection;
+        ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
+        ball.velocity = ballSpeed * initialDirection;
     }
 
     // upon hitting a paddle, reflect the ball. everything else is taken care (ie walls) of automatically by colliders
@@ -18,7 +18,7 @@ public class BallController : MonoBehaviour
     {
         if (collision.gameObject.CompareTag("Paddle"))
         {
-            ball.velocity = moveSpeed * ComputeBounceDirection(ball.position, collision.rigidbody.position, collision.collider);
+            ball.velocity = ballSpeed * ComputeBounceDirection(ball.position, collision.rigidbody.position, collision.collider);
         }
     }
     private Vector2 ComputeBounceDirection(Vector2 ballPosition, Vector2 paddlePosition, Collider2D paddleCollider)

--- a/Assets/Scripts/BallController.cs
+++ b/Assets/Scripts/BallController.cs
@@ -7,7 +7,6 @@ public class BallController : MonoBehaviour
 
     private Rigidbody2D ball;
 
-
     void Start()
     {
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -2,18 +2,19 @@
 
 public class PlayerController : MonoBehaviour
 {
-    public float moveSpeed;
+    public string paddleName;
+    public float paddleSpeed;
     public string inputAxisName;
 
-    private int score;
-    private Rigidbody2D paddle;
-    private Vector2 inputVelocity;
+    [HideInInspector] public int score;
 
+    private Vector2 inputVelocity;
+    private Rigidbody2D paddle;
     private Rigidbody2D ball;
-    
+
     void Start()
     {
-        paddle = GameObject.Find("PlayerPaddle").GetComponent<Rigidbody2D>();
+        paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
 
         score = 0;
@@ -23,7 +24,7 @@ public class PlayerController : MonoBehaviour
     
     void Update()
     {
-        inputVelocity = new Vector2(0, moveSpeed * Input.GetAxisRaw(inputAxisName));
+        inputVelocity = new Vector2(0, paddleSpeed * Input.GetAxisRaw(inputAxisName));
     }
 
     void FixedUpdate()

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -21,7 +21,7 @@ public class PlayerController : MonoBehaviour
         inputVelocity = Vector2.zero;
         paddle.velocity = inputVelocity;
     }
-    
+
     void Update()
     {
         inputVelocity = new Vector2(0, paddleSpeed * Input.GetAxisRaw(inputAxisName));

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -5,22 +5,29 @@ public class PlayerController : MonoBehaviour
     public float moveSpeed;
     public string inputAxisName;
 
+    private int score;
     private Rigidbody2D paddle;
-    private Vector2 moveDirection;
+    private Vector2 inputVelocity;
+
+    private Rigidbody2D ball;
     
     void Start()
     {
         paddle = GameObject.Find("PlayerPaddle").GetComponent<Rigidbody2D>();
-        paddle.velocity = Vector2.zero;
-    }
+        ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
 
+        score = 0;
+        inputVelocity = Vector2.zero;
+        paddle.velocity = inputVelocity;
+    }
+    
     void Update()
     {
-        moveDirection = new Vector2(0, Input.GetAxisRaw(inputAxisName));
+        inputVelocity = new Vector2(0, moveSpeed * Input.GetAxisRaw(inputAxisName));
     }
 
     void FixedUpdate()
     {
-        paddle.velocity = moveSpeed * moveDirection;
+        paddle.velocity = inputVelocity;
     }
 }


### PR DESCRIPTION
# [Add score keeping for both players](https://github.com/jeffreypersons/Pong/issues/7)
* Score now updates for the paddle controller on the opposite side of the arena, upon the ball colliding with a vertical wall.
* Note that this is only about the score book keeping logic and nothing else.

## Changes include:
* colliders for arena walls
* score fields, initialized at zero for both paddle controllers
* checks for left and right wall collisions in ball class and increments corresponding player's score by one

## Improvements to be made in future:
* instead of incrementing the score directly in the ball class (as done now), replace with a much cleaner event trigger like `vertical wall hit` thats handled in a separate `score system` class