### PR TITLE
Respawn ball upon hitting vertical wall

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -543,6 +543,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   paddleName: RightPaddle
   paddleSpeed: 30
+  initialPosition: {x: 0, y: 0}
   score: 0
 --- !u!1001 &871942651
 PrefabInstance:
@@ -680,6 +681,7 @@ MonoBehaviour:
   paddleName: LeftPaddle
   paddleSpeed: 30
   inputAxisName: Vertical
+  initialPosition: {x: 0, y: 0}
   score: 0
 --- !u!1001 &1438342285
 PrefabInstance:

--- a/Assets/Scripts/AiController.cs
+++ b/Assets/Scripts/AiController.cs
@@ -4,6 +4,7 @@ public class AiController : MonoBehaviour
 {
     public string paddleName;
     public float paddleSpeed;
+    public Vector2 initialPosition;
 
     [HideInInspector] public int score;
 
@@ -12,9 +13,10 @@ public class AiController : MonoBehaviour
 
     void Start()
     {
-        score = 0;
         paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
+
+        score = 0;
     }
 
     void FixedUpdate()

--- a/Assets/Scripts/AiController.cs
+++ b/Assets/Scripts/AiController.cs
@@ -4,9 +4,9 @@ public class AiController : MonoBehaviour
 {
     public string paddleName;
     public float paddleSpeed;
-    public Vector2 initialPosition;
 
     [HideInInspector] public int score;
+    [HideInInspector] public Vector2 initialPosition;
 
     private Rigidbody2D paddle;
     private Rigidbody2D ball;
@@ -17,6 +17,7 @@ public class AiController : MonoBehaviour
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
 
         score = 0;
+        initialPosition = paddle.position;
     }
 
     void FixedUpdate()

--- a/Assets/Scripts/BallController.cs
+++ b/Assets/Scripts/BallController.cs
@@ -25,6 +25,8 @@ public class BallController : MonoBehaviour
         }
         if (collision.gameObject.CompareTag("VerticalWall"))
         {
+            // for now scoring logic handled within ball class, but external event system would be preferred
+            // see https://github.com/jeffreypersons/Pong/issues/9
             UpdateScoreOnHittingWall(collision.gameObject.name);
         }
     }
@@ -36,7 +38,6 @@ public class BallController : MonoBehaviour
     }
     private void UpdateScoreOnHittingWall(string wallName)
     {
-        // really, really bad, but will be replaced by a proper event system for scoring during next refactoring day!
         if (wallName == "LeftWall")
         {
             GameObject.Find("RightPaddle").GetComponent<AiController>().score += 1;

--- a/Assets/Scripts/BallController.cs
+++ b/Assets/Scripts/BallController.cs
@@ -5,12 +5,16 @@ public class BallController : MonoBehaviour
     public float ballSpeed;
     public Vector2 initialDirection;
 
+    [HideInInspector] public Vector2 initialPosition;
+
     private Rigidbody2D ball;
 
     void Start()
     {
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
         ball.velocity = ballSpeed * initialDirection;
+
+        initialPosition = ball.position;
     }
 
     void OnCollisionEnter2D(Collision2D collision)
@@ -28,6 +32,7 @@ public class BallController : MonoBehaviour
             // for now scoring logic handled within ball class, but external event system would be preferred
             // see https://github.com/jeffreypersons/Pong/issues/9
             UpdateScoreOnHittingWall(collision.gameObject.name);
+            ResetPositions();
         }
     }
     private Vector2 ComputeBounceDirection(Vector2 ballPosition, Vector2 paddlePosition, Collider2D paddleCollider)
@@ -46,5 +51,16 @@ public class BallController : MonoBehaviour
         {
             GameObject.Find("LeftPaddle").GetComponent<PlayerController>().score += 1;
         }
+    }
+    private void ResetPositions()
+    {
+        ball.position = initialPosition;
+        ball.velocity = ballSpeed * initialDirection;
+
+        PlayerController leftController = GameObject.Find("LeftPaddle").GetComponent<PlayerController>();
+        leftController.GetComponent<Rigidbody2D>().position = leftController.initialPosition;
+
+        AiController rightController = GameObject.Find("RightPaddle").GetComponent<AiController>();
+        rightController.GetComponent<Rigidbody2D>().position = rightController.initialPosition;
     }
 }

--- a/Assets/Scripts/BallController.cs
+++ b/Assets/Scripts/BallController.cs
@@ -13,21 +13,19 @@ public class BallController : MonoBehaviour
         ball.velocity = ballSpeed * initialDirection;
     }
 
-    // upon hitting a paddle, reflect the ball. everything else is taken care (ie walls) of automatically by colliders
     void OnCollisionEnter2D(Collision2D collision)
     {
         if (collision.gameObject.CompareTag("Paddle"))
         {
             ball.velocity = ballSpeed * ComputeBounceDirection(ball.position, collision.rigidbody.position, collision.collider);
         }
-        // really, really bad, but will be replaced by a proper event system for scoring during next refactoring day!
-        else if (collision.gameObject.name == "LeftWall")
+        if (collision.gameObject.CompareTag("HorizontalWall"))
         {
-            GameObject.Find("RightPaddle").GetComponent<AiController>().score += 1;
+            // desired behavior already handled by collider defaults
         }
-        else if (collision.gameObject.name == "RightWall")
+        if (collision.gameObject.CompareTag("VerticalWall"))
         {
-            GameObject.Find("LeftPaddle").GetComponent<PlayerController>().score += 1;
+            UpdateScoreOnHittingWall(collision.gameObject.name);
         }
     }
     private Vector2 ComputeBounceDirection(Vector2 ballPosition, Vector2 paddlePosition, Collider2D paddleCollider)
@@ -35,5 +33,17 @@ public class BallController : MonoBehaviour
         float invertedXDirection = ballPosition.x - paddlePosition.x > 0 ? -1 : 1;
         float offsetFromPaddleCenterToBall = (ball.position.y - paddlePosition.y) / paddleCollider.bounds.size.y;
         return new Vector2(invertedXDirection, offsetFromPaddleCenterToBall).normalized;
+    }
+    private void UpdateScoreOnHittingWall(string wallName)
+    {
+        // really, really bad, but will be replaced by a proper event system for scoring during next refactoring day!
+        if (wallName == "LeftWall")
+        {
+            GameObject.Find("RightPaddle").GetComponent<AiController>().score += 1;
+        }
+        else if (wallName == "RightWall")
+        {
+            GameObject.Find("LeftPaddle").GetComponent<PlayerController>().score += 1;
+        }
     }
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -14,12 +14,12 @@ public class PlayerController : MonoBehaviour
 
     void Start()
     {
-        paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
-        ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
-
         score = 0;
         inputVelocity = Vector2.zero;
         paddle.velocity = inputVelocity;
+
+        paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
+        ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
     }
 
     void Update()

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -5,9 +5,9 @@ public class PlayerController : MonoBehaviour
     public string paddleName;
     public float paddleSpeed;
     public string inputAxisName;
-    public Vector2 initialPosition;
 
     [HideInInspector] public int score;
+    [HideInInspector] public Vector2 initialPosition;
 
     private Vector2 inputVelocity;
     private Rigidbody2D paddle;
@@ -21,6 +21,7 @@ public class PlayerController : MonoBehaviour
         score = 0;
         inputVelocity = Vector2.zero;
         paddle.velocity = inputVelocity;
+        initialPosition = paddle.position;
     }
 
     void Update()

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -5,6 +5,7 @@ public class PlayerController : MonoBehaviour
     public string paddleName;
     public float paddleSpeed;
     public string inputAxisName;
+    public Vector2 initialPosition;
 
     [HideInInspector] public int score;
 
@@ -14,12 +15,12 @@ public class PlayerController : MonoBehaviour
 
     void Start()
     {
+        paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
+        ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
+
         score = 0;
         inputVelocity = Vector2.zero;
         paddle.velocity = inputVelocity;
-
-        paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
-        ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
     }
 
     void Update()


### PR DESCRIPTION
[issue #4: respawn ball upon hitting vertical wall](https://github.com/jeffreypersons/Pong/issues/4)

Upon hitting a vertical wall (aka scoring a goal) - the balls and paddles now restore to their initial velocities and positions.

This means that the game keeps going, resetting (except with the score increasing).