### PR TITLE
Move majority of scorekeeping to outside ball controller 

### DIFF
--- a/Assets/Prefabs/data_manager.prefab
+++ b/Assets/Prefabs/data_manager.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7345667674539526564
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7345667674539526567}
+  - component: {fileID: 7345667674539526566}
+  m_Layer: 0
+  m_Name: DataManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7345667674539526567
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7345667674539526564}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7345667674539526566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7345667674539526564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32e0aaed2681f6b4c8975d9b8223980b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  WINNING_SCORE: 5

--- a/Assets/Prefabs/data_manager.prefab.meta
+++ b/Assets/Prefabs/data_manager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 677be52d860fc074e94976c68f2b8c4a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/EndMenu.unity
+++ b/Assets/Scenes/EndMenu.unity
@@ -170,7 +170,7 @@ PrefabInstance:
     - target: {fileID: 10405006053755535, guid: 2d2aa87f09491f04e98c4e1eda24c12d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 10405006053755535, guid: 2d2aa87f09491f04e98c4e1eda24c12d,
         type: 3}
@@ -195,6 +195,75 @@ Camera:
     type: 3}
   m_PrefabInstance: {fileID: 68819001}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &254479844
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7345667674539526564, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_Name
+      value: DataManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 677be52d860fc074e94976c68f2b8c4a, type: 3}
 --- !u!1 &907627461
 GameObject:
   m_ObjectHideFlags: 0
@@ -206,7 +275,7 @@ GameObject:
   - component: {fileID: 907627462}
   m_Layer: 0
   m_Name: EndGameScreen
-  m_TagString: Untagged
+  m_TagString: Screen
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -224,7 +293,7 @@ Transform:
   m_Children:
   - {fileID: 773325548827515614}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1189049437
 PrefabInstance:
@@ -271,7 +340,7 @@ PrefabInstance:
     - target: {fileID: 645851654980869984, guid: c6425e6aa447b8b4e95aabdc53eb20b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 645851654980869984, guid: c6425e6aa447b8b4e95aabdc53eb20b3,
         type: 3}
@@ -326,8 +395,9 @@ GameObject:
   - component: {fileID: 1931647833}
   - component: {fileID: 1931647832}
   - component: {fileID: 3964460216351445264}
+  - component: {fileID: 1931647834}
   m_Layer: 5
-  m_Name: GameOutcome
+  m_Name: GameOutcomeLabel
   m_TagString: TextLabel
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -451,6 +521,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1931647831}
   m_CullTransparentMesh: 0
+--- !u!114 &1931647834
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1931647831}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 63fc5a22c03401e49b80ac9fd739afa0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &773325548827515608
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -542,7 +624,6 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1884730412}
-  - {fileID: 1774211385271889166}
   - {fileID: 3449679235299196465}
   - {fileID: 3449679234818925609}
   m_Father: {fileID: 907627462}
@@ -574,162 +655,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!1 &1774211385226527349
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1774211385271889166}
-  - component: {fileID: 1774211385226527355}
-  - component: {fileID: 1774211385226527354}
-  - component: {fileID: 7507703257372079426}
-  m_Layer: 5
-  m_Name: GameScore
-  m_TagString: TextLabel
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
-  m_IsActive: 1
---- !u!114 &1774211385226527354
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1774211385226527349}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Score
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_outlineColor:
-    serializedVersion: 2
-    rgba: 4278190080
-  m_fontSize: 53.7
-  m_fontSizeBase: 24
-  m_fontWeight: 400
-  m_enableAutoSizing: 1
-  m_fontSizeMin: 25
-  m_fontSizeMax: 175
-  m_fontStyle: 1
-  m_textAlignment: 544
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_firstOverflowCharacterIndex: -1
-  m_linkedTextComponent: {fileID: 0}
-  m_isLinkedTextComponent: 0
-  m_isTextTruncated: 0
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_ignoreRectMaskCulling: 0
-  m_ignoreCulling: 1
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_VertexBufferAutoSizeReduction: 1
-  m_firstVisibleCharacter: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 50, y: 0, z: 50, w: 0}
-  m_textInfo:
-    textComponent: {fileID: 1774211385226527354}
-    characterCount: 5
-    spriteCount: 0
-    spaceCount: 0
-    wordCount: 1
-    linkCount: 0
-    lineCount: 1
-    pageCount: 1
-    materialCount: 1
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
-  m_subTextObjects:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &1774211385226527355
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1774211385226527349}
-  m_CullTransparentMesh: 0
---- !u!224 &1774211385271889166
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1774211385226527349}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 0}
-  m_Children: []
-  m_Father: {fileID: 773325548827515614}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -30}
-  m_SizeDelta: {x: 0, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!4 &3449679234413876618
 Transform:
   m_ObjectHideFlags: 0
@@ -806,11 +731,11 @@ RectTransform:
   - {fileID: 3449679235469790594}
   - {fileID: 3449679234413876618}
   m_Father: {fileID: 773325548827515614}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -175}
+  m_AnchoredPosition: {x: 0, y: -140}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3449679234818925652
@@ -1093,11 +1018,11 @@ RectTransform:
   - {fileID: 3449679234985301914}
   - {fileID: 3449679235972009874}
   m_Father: {fileID: 773325548827515614}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -115}
+  m_AnchoredPosition: {x: 0, y: -80}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3449679235299196492
@@ -1395,26 +1320,6 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1931647831}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreLayout: 0
-  m_MinWidth: -1
-  m_MinHeight: -1
-  m_PreferredWidth: -1
-  m_PreferredHeight: -1
-  m_FlexibleWidth: -1
-  m_FlexibleHeight: -1
-  m_LayoutPriority: 1
---- !u!114 &7507703257372079426
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1774211385226527349}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}

--- a/Assets/Scenes/StartMenu.unity
+++ b/Assets/Scenes/StartMenu.unity
@@ -170,7 +170,7 @@ PrefabInstance:
     - target: {fileID: 10405006053755535, guid: 2d2aa87f09491f04e98c4e1eda24c12d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 10405006053755535, guid: 2d2aa87f09491f04e98c4e1eda24c12d,
         type: 3}
@@ -240,7 +240,7 @@ PrefabInstance:
     - target: {fileID: 645851654980869984, guid: c6425e6aa447b8b4e95aabdc53eb20b3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 645851654980869984, guid: c6425e6aa447b8b4e95aabdc53eb20b3,
         type: 3}
@@ -264,6 +264,75 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c6425e6aa447b8b4e95aabdc53eb20b3, type: 3}
+--- !u!1001 &1414647586
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7345667674539526564, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_Name
+      value: DataManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7345667674539526567, guid: 677be52d860fc074e94976c68f2b8c4a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 677be52d860fc074e94976c68f2b8c4a, type: 3}
 --- !u!1001 &3964460216351445259
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -329,7 +398,7 @@ PrefabInstance:
     - target: {fileID: 3964460216184117965, guid: 2ff4ec89601c4e04eb38936f6ae45937,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3964460216184117965, guid: 2ff4ec89601c4e04eb38936f6ae45937,
         type: 3}
@@ -354,7 +423,7 @@ PrefabInstance:
     - target: {fileID: 3964460216184117966, guid: 2ff4ec89601c4e04eb38936f6ae45937,
         type: 3}
       propertyPath: m_TagString
-      value: Canvas
+      value: Screen
       objectReference: {fileID: 0}
     - target: {fileID: 4449539881727871956, guid: 2ff4ec89601c4e04eb38936f6ae45937,
         type: 3}

--- a/Assets/Scripts/AiController.cs
+++ b/Assets/Scripts/AiController.cs
@@ -5,7 +5,6 @@ public class AiController : MonoBehaviour
     public string paddleName;
     public float paddleSpeed;
 
-    [HideInInspector] public int score;
     [HideInInspector] public Vector2 initialPosition;
 
     private Rigidbody2D paddle;
@@ -16,7 +15,6 @@ public class AiController : MonoBehaviour
         paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
 
-        score = 0;
         initialPosition = paddle.position;
     }
 

--- a/Assets/Scripts/BallController.cs
+++ b/Assets/Scripts/BallController.cs
@@ -28,12 +28,10 @@ public class BallController : MonoBehaviour
         {
             // desired behavior already handled by collider defaults
         }
-        // REALLY UGLY, I KNOW! this tech debt will be addressed in the next issue through thorough refactoring.
         if (collision.gameObject.CompareTag("VerticalWall"))
         {
-            // for now scoring logic handled within ball class, but an external event system
-            // would be preferred, with less code duplication
-            // see https://github.com/jeffreypersons/Pong/issues/9
+            // for now some scoring logic/position-resetting logic is still handled within ball class,
+            // despite recent decoupling, but an external event system would be better...
             var data = DataManager.instance;
             switch (collision.gameObject.name)
             {

--- a/Assets/Scripts/BallController.cs
+++ b/Assets/Scripts/BallController.cs
@@ -34,48 +34,20 @@ public class BallController : MonoBehaviour
             // for now scoring logic handled within ball class, but an external event system
             // would be preferred, with less code duplication
             // see https://github.com/jeffreypersons/Pong/issues/9
+            var data = DataManager.instance;
             switch (collision.gameObject.name)
             {
-                case "LeftWall":  IncrementRightPlayerScore(); break;
-                case "RightWall": IncrementLeftPlayerScore();  break;
+                case "LeftWall":  data.player2Score += 1; break;
+                case "RightWall": data.player1Score += 1; break;
             }
-            const int WINNING_SCORE = 5;
-            int playerScore  = GameObject.Find("LeftPaddle").GetComponent<PlayerController>().score;
-            int aiScore = GameObject.Find("RightPaddle").GetComponent<AiController>().score;
 
-            if (playerScore == WINNING_SCORE)
+            GameObject.Find("LeftPlayerScore").GetComponent<TMPro.TextMeshProUGUI>().text = DataManager.instance.player1Score.ToString();
+            GameObject.Find("RightPlayerScore").GetComponent<TMPro.TextMeshProUGUI>().text = DataManager.instance.player2Score.ToString();
+            if (data.player1Score == data.WINNING_SCORE || data.player2Score == data.WINNING_SCORE)
             {
-                GameObject.Find("LeftPaddle").GetComponent<PlayerController>().score = 0;
-                GameObject.Find("RightPaddle").GetComponent<AiController>().score = 0;
-
                 SceneManager.LoadScene("EndMenu");
-
-                // the mechanics for updating the endgame text wont work here as it would have to wait until next frame
-                // is loaded in the newly loaded endmenu scene, so this will have to wait until score system refactor
-                /*
-                GameObject.Find("EndGameScreen").GetComponent("Canvas")
-                    .GetComponent("GameOutcome").GetComponent<TMPro.TextMeshProUGUI>().text = "Game Won";
-                GameObject.Find("GameScore").GetComponent<TMPro.TextMeshProUGUI>().text =
-                    playerScore.ToString() + " - " + aiScore.ToString();
-                */
             }
-            else if (aiScore == WINNING_SCORE)
-            {
-                GameObject.Find("LeftPaddle").GetComponent<PlayerController>().score = 0;
-                GameObject.Find("RightPaddle").GetComponent<AiController>().score = 0;
-
-                SceneManager.LoadScene("EndMenu");
-
-                // the mechanics for updating the endgame text wont work here as it would have to wait until next frame
-                // is loaded in the newly loaded endmenu scene, so this will have to wait until score system refactor
-                /*
-                GameObject.Find("EndGameScreen").GetComponent("Canvas")
-                    .GetComponent("GameOutcome").GetComponent<TMPro.TextMeshProUGUI>().text = "Game Lost";
-                GameObject.Find("GameScore").GetComponent<TMPro.TextMeshProUGUI>().text =
-                    playerScore.ToString() + " - " + aiScore.ToString();
-                */
-            }
-
+            data.ResetAll();
             ResetPositions();
         }
     }
@@ -85,18 +57,6 @@ public class BallController : MonoBehaviour
         float invertedXDirection = ballPosition.x - paddlePosition.x > 0 ? -1 : 1;
         float offsetFromPaddleCenterToBall = (ball.position.y - paddlePosition.y) / paddleCollider.bounds.size.y;
         return new Vector2(invertedXDirection, offsetFromPaddleCenterToBall).normalized;
-    }
-    private void IncrementLeftPlayerScore()
-    {
-        PlayerController controller = GameObject.Find("LeftPaddle").GetComponent<PlayerController>();
-        controller.score += 1;
-        GameObject.Find("LeftPlayerScore").GetComponent<TMPro.TextMeshProUGUI>().text = controller.score.ToString();
-    }
-    private void IncrementRightPlayerScore()
-    {
-        AiController controller = GameObject.Find("RightPaddle").GetComponent<AiController>();
-        controller.score += 1;
-        GameObject.Find("RightPlayerScore").GetComponent<TMPro.TextMeshProUGUI>().text = controller.score.ToString();
     }
     private void ResetPositions()
     {

--- a/Assets/Scripts/ComputeGameOutcome.cs
+++ b/Assets/Scripts/ComputeGameOutcome.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine;
+
+public class ComputeGameOutcome : MonoBehaviour
+{
+    void Start()
+    {
+        var data = DataManager.instance;
+        var resultsLabel = GameObject.Find(transform.name).GetComponent<TMPro.TextMeshProUGUI>();
+
+        resultsLabel.text = data.player1Score == data.WINNING_SCORE ? "Game Won" : "Game Lost";
+        resultsLabel.text += "\n" + data.player1Score.ToString() + " - " + data.player2Score.ToString();
+    }
+}

--- a/Assets/Scripts/ComputeGameOutcome.cs.meta
+++ b/Assets/Scripts/ComputeGameOutcome.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63fc5a22c03401e49b80ac9fd739afa0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/DataManager.cs
+++ b/Assets/Scripts/DataManager.cs
@@ -1,0 +1,37 @@
+﻿using UnityEngine;
+
+// singleton class for managing data that needs to be persisted across scenes
+public class DataManager : MonoBehaviour {
+    public static DataManager instance { get; set; }
+
+    public int WINNING_SCORE;
+    [HideInInspector] public int player1Score { get; set; }
+    [HideInInspector] public int player2Score { get; set; }
+
+    void Awake () {
+        InitializeAsPersistentSingleton();
+    }
+
+    void Start() {
+        ResetAll();
+    }
+
+    public void ResetAll()
+    {
+        player1Score = 0;
+        player2Score = 0;
+    }
+
+    private void InitializeAsPersistentSingleton()
+    {
+        if (instance == null)
+        {
+            instance = this;
+        }
+        else if (instance != this)
+        {
+            Destroy(gameObject);
+        }
+        DontDestroyOnLoad(gameObject);
+    }
+}

--- a/Assets/Scripts/DataManager.cs.meta
+++ b/Assets/Scripts/DataManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32e0aaed2681f6b4c8975d9b8223980b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -6,7 +6,6 @@ public class PlayerController : MonoBehaviour
     public float paddleSpeed;
     public string inputAxisName;
 
-    [HideInInspector] public int score;
     [HideInInspector] public Vector2 initialPosition;
 
     private Vector2 inputVelocity;
@@ -18,7 +17,6 @@ public class PlayerController : MonoBehaviour
         paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
 
-        score = 0;
         inputVelocity = Vector2.zero;
         paddle.velocity = inputVelocity;
         initialPosition = paddle.position;

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,9 +6,12 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/StartGame.unity
+    path: Assets/Scenes/StartMenu.unity
     guid: 04aabb04d69c60c4a9f95c6aad3fba34
   - enabled: 1
     path: Assets/Scenes/Game.unity
     guid: 2cda990e2423bbf4892e6590ba056729
+  - enabled: 1
+    path: Assets/Scenes/EndMenu.unity
+    guid: d5450779c399b7a46b6c9f95d5b2deb1
   m_configObjects: {}


### PR DESCRIPTION
# [Move majority of scorekeeping to outside ball controller](https://github.com/jeffreypersons/Pong/issues/9)
Part of a series on addressing tech debt, today's PR focuses on reducing the nastiness of scoring logic done within the ball class itself.

While there is still a bit left to be done as far as refactoring is concerned, this a step in decoupling things this PR makes significant improvement in reducing the cruft down from a 100 lines or too just two dozen or so cleaner lines, utilizing a new `DataManager` class.

Also, as a side effect, it fixes the endgame loading scores, now that updates are done in the correct order (yes, a bit beyond a pure refactoring but oh well!).

**_Ideally, we'd have a purely separated logic from the ball controller, but this solves a lot of the intermediate issues for now._**

# TLDR
* Reduce duplication by storing scores in a data manager singleton
* Update disclaimer comments on coupling in ball class
* As a side effect in refactoring the score system, the scene execution order for changing the text labels in the endgame menu now work as intended