### PR TITLE
Add goal (onVerticalWallHit) events

### DIFF
--- a/Assets/Code/Controllers/AiController.cs
+++ b/Assets/Code/Controllers/AiController.cs
@@ -6,11 +6,37 @@ public class AiController : MonoBehaviour
     public float paddleSpeed;
     public float responseTime;
 
-    [HideInInspector] public Vector2 initialPosition;
-
-    private Rigidbody2D paddle;
-    private Rigidbody2D ball;
+    private Vector2 initialPosition;
     private Vector2 positionToMoveTowards;
+    private Rigidbody2D paddle;
+
+    public void Reset()
+    {
+        paddle.position = initialPosition;
+        positionToMoveTowards = initialPosition;
+        paddle.velocity = Vector2.zero;
+    }
+    void Start()
+    {
+        paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
+        initialPosition = paddle.position;
+        Reset();
+    }
+
+    void FixedUpdate()
+    {
+        // todo: invoke a predict ball position script here instead
+        float ballPositionY = GameObject.Find("Ball").GetComponent<Rigidbody2D>().position.y;
+
+        Vector2 current = paddle.position;
+        positionToMoveTowards = new Vector2(current.x, ballPositionY);
+        float currentSpeed = Random.Range(0.10f, 1.0f) * paddleSpeed;
+
+        if (positionToMoveTowards != initialPosition)
+        {
+            paddle.position = Vector2.MoveTowards(current, positionToMoveTowards, currentSpeed * Time.deltaTime);
+        }
+    }
 
     void OnEnable()
     {
@@ -20,23 +46,7 @@ public class AiController : MonoBehaviour
     {
         GameEvents.onPaddleHit.RemoveListener(UpdateTargetPosition);
     }
-
-    void Start()
-    {
-        paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
-        ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
-
-        initialPosition = paddle.position;
-    }
-
-    void FixedUpdate()
-    {
-        Vector2 current = paddle.position;
-        positionToMoveTowards = new Vector2(current.x, ball.position.y);
-        float currentSpeed = Random.Range(0.10f, 1.0f) * paddleSpeed;
-        paddle.position = Vector2.MoveTowards(current, positionToMoveTowards, currentSpeed * Time.deltaTime);
-    }
-    void UpdateTargetPosition(string paddleName)
+    public void UpdateTargetPosition(string paddleName)
     {
         if (paddleName == "LeftPaddle")
         {

--- a/Assets/Code/Controllers/BallController.cs
+++ b/Assets/Code/Controllers/BallController.cs
@@ -1,21 +1,23 @@
 ﻿using UnityEngine;
-using UnityEngine.SceneManagement;
 
 public class BallController : MonoBehaviour
 {
     public float ballSpeed;
     public Vector2 initialDirection;
 
-    [HideInInspector] public Vector2 initialPosition;
-
+    private Vector2 initialPosition;
     private Rigidbody2D ball;
 
+    public void Reset()
+    {
+        ball.position = initialPosition;
+        ball.velocity = ballSpeed * initialDirection;
+    }
     void Start()
     {
         ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
-        ball.velocity = ballSpeed * initialDirection;
-
         initialPosition = ball.position;
+        Reset();
     }
 
     void OnCollisionEnter2D(Collision2D collision)
@@ -31,14 +33,7 @@ public class BallController : MonoBehaviour
         }
         if (collision.gameObject.CompareTag("VerticalWall"))
         {
-            // for now some scoring logic/position-resetting logic is still handled within ball class,
-            // despite recent decoupling, but an external event system would be better...
-            IncrementScoreBasedOnGoal(collision.gameObject.name);
-            if (HasWinningPlayer())
-            {
-                SceneManager.LoadScene("EndMenu");
-            }
-            ResetPositions();
+            GameEvents.onVerticalWallHit.Invoke(collision.gameObject.name);
         }
     }
 
@@ -47,35 +42,5 @@ public class BallController : MonoBehaviour
         float invertedXDirection = ballPosition.x - paddlePosition.x > 0 ? -1 : 1;
         float offsetFromPaddleCenterToBall = (ball.position.y - paddlePosition.y) / paddleCollider.bounds.size.y;
         return new Vector2(invertedXDirection, offsetFromPaddleCenterToBall).normalized;
-    }
-    private void IncrementScoreBasedOnGoal(string goalName)
-    {
-        var data = DataManager.instance;
-        if (goalName == "LeftWall")
-        {
-            data.player2Score += 1;
-            GameObject.Find("RightPlayerScore").GetComponent<TMPro.TextMeshProUGUI>().text = data.player2Score.ToString();
-        }
-        else if (goalName == "RightWall")
-        {
-            data.player1Score += 1;
-            GameObject.Find("LeftPlayerScore").GetComponent<TMPro.TextMeshProUGUI>().text = data.player1Score.ToString();
-        }
-    }
-    private bool HasWinningPlayer()
-    {
-        var data = DataManager.instance;
-        return (data.player1Score == data.WINNING_SCORE || data.player2Score == data.WINNING_SCORE);
-    }
-    private void ResetPositions()
-    {
-        ball.position = initialPosition;
-        ball.velocity = ballSpeed * initialDirection;
-
-        PlayerController leftController = GameObject.Find("LeftPaddle").GetComponent<PlayerController>();
-        leftController.GetComponent<Rigidbody2D>().position = leftController.initialPosition;
-
-        AiController rightController = GameObject.Find("RightPaddle").GetComponent<AiController>();
-        rightController.GetComponent<Rigidbody2D>().position = rightController.initialPosition;
     }
 }

--- a/Assets/Code/Controllers/GameEvents.cs
+++ b/Assets/Code/Controllers/GameEvents.cs
@@ -4,7 +4,9 @@ using UnityEngine.Events;
 [System.Serializable]
 public class StringEvent : UnityEvent<string> { }
 
+// note events are triggered and handled programmatically (via listeners and invocations)
 public class GameEvents : MonoBehaviour
 {
     public static StringEvent onPaddleHit = new StringEvent();
+    public static StringEvent onVerticalWallHit = new StringEvent();
 }

--- a/Assets/Code/Controllers/PlayerController.cs
+++ b/Assets/Code/Controllers/PlayerController.cs
@@ -6,27 +6,26 @@ public class PlayerController : MonoBehaviour
     public float paddleSpeed;
     public string inputAxisName;
 
-    [HideInInspector] public Vector2 initialPosition;
-
+    private Vector2 initialPosition;
     private Vector2 inputVelocity;
     private Rigidbody2D paddle;
-    private Rigidbody2D ball;
 
+    public void Reset()
+    {
+        inputVelocity = Vector2.zero;
+        paddle.velocity = inputVelocity;
+        paddle.position = initialPosition;
+    }
     void Start()
     {
         paddle = GameObject.Find(paddleName).GetComponent<Rigidbody2D>();
-        ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
-
-        inputVelocity = Vector2.zero;
-        paddle.velocity = inputVelocity;
         initialPosition = paddle.position;
+        Reset();
     }
-
     void Update()
     {
         inputVelocity = new Vector2(0, paddleSpeed * Input.GetAxisRaw(inputAxisName));
     }
-
     void FixedUpdate()
     {
         paddle.velocity = inputVelocity;

--- a/Assets/Code/Scripts/StartNextRound.cs
+++ b/Assets/Code/Scripts/StartNextRound.cs
@@ -1,0 +1,63 @@
+﻿using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class StartNextRound : MonoBehaviour
+{
+    private BallController ballController;
+    private PlayerController leftPaddleController;
+    private AiController rightPaddleController;
+
+    private TMPro.TextMeshProUGUI leftScoreLabel;
+    private TMPro.TextMeshProUGUI rightScoreLabel;
+
+    void Start()
+    {
+        // todo: add listeners for player scores instead in a separate script or something,
+        // so they simply just change when `data.player1Score` and `data.player2Score` change
+        ballController = GameObject.Find("Ball").GetComponent<BallController>();
+        leftPaddleController = GameObject.Find("LeftPaddle").GetComponent<PlayerController>();
+        rightPaddleController = GameObject.Find("RightPaddle").GetComponent<AiController>();
+
+        leftScoreLabel = GameObject.Find("LeftPlayerScore").GetComponent<TMPro.TextMeshProUGUI>();
+        rightScoreLabel = GameObject.Find("RightPlayerScore").GetComponent<TMPro.TextMeshProUGUI>();
+    }
+
+    void OnEnable()
+    {
+        GameEvents.onVerticalWallHit.AddListener(MoveToNextRound);
+    }
+    void OnDisable()
+    {
+        GameEvents.onVerticalWallHit.RemoveListener(MoveToNextRound);
+    }
+    public void MoveToNextRound(string goalName)
+    {
+        IncrementScoreBasedOnGoal(goalName);
+        if (HasWinningPlayer())
+        {
+            SceneManager.LoadScene("EndMenu");
+        }
+        ballController.Reset();
+        leftPaddleController.Reset();
+        rightPaddleController.Reset();
+    }
+    private void IncrementScoreBasedOnGoal(string goalName)
+    {
+        var data = DataManager.instance;
+        if (goalName == "LeftWall")
+        {
+            data.player2Score += 1;
+            rightScoreLabel.text = data.player2Score.ToString();
+        }
+        else if (goalName == "RightWall")
+        {
+            data.player1Score += 1;
+            leftScoreLabel.text = data.player1Score.ToString();
+        }
+    }
+    private bool HasWinningPlayer()
+    {
+        var data = DataManager.instance;
+        return (data.player1Score == data.WINNING_SCORE || data.player2Score == data.WINNING_SCORE);
+    }
+}

--- a/Assets/Code/Scripts/StartNextRound.cs.meta
+++ b/Assets/Code/Scripts/StartNextRound.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0a28b488f105c94bb50ceb1eae5a5ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -297,6 +297,49 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &117259441
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 117259442}
+  - component: {fileID: 117259443}
+  m_Layer: 0
+  m_Name: GameRounds
+  m_TagString: Scripter
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &117259442
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 117259441}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &117259443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 117259441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c0a28b488f105c94bb50ceb1eae5a5ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!20 &157880718 stripped
 Camera:
   m_CorrespondingSourceObject: {fileID: 10405006053755504, guid: 2d2aa87f09491f04e98c4e1eda24c12d,
@@ -802,7 +845,6 @@ MonoBehaviour:
   paddleName: RightPaddle
   paddleSpeed: 30
   responseTime: 0.02
-  initialPosition: {x: 0, y: 0}
 --- !u!1 &1126169004
 GameObject:
   m_ObjectHideFlags: 0
@@ -881,7 +923,6 @@ MonoBehaviour:
   paddleName: LeftPaddle
   paddleSpeed: 30
   inputAxisName: Vertical
-  initialPosition: {x: 0, y: 0}
 --- !u!1 &1430003660
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# Add goal (onVerticalWallHit) events
Similar to the paddle events done previously, we now have the event `OnVerticalWallHit` which is triggered and prompts the `StartNextRound` script, which listens to that event (and where most of the previously in the `Ball` controller scorekeeping and round management logic was previously located [finally!]).

## Details
* Adds event `OnVerticalWallHit` triggered by `Ball` controller and listened to by the `StartNextRound` game object script in the game scene
* Moves scorekeeping and round management logic from `Ball` controller to `StartNextRound` script (which handles score, resets, and endgame conditions, just as before).