### PR TITLE
Add on score changed event with associated ui controller

### DIFF
--- a/Assets/Code/Controllers/GameController.cs
+++ b/Assets/Code/Controllers/GameController.cs
@@ -39,7 +39,7 @@ public class GameController : MonoBehaviour
     public void MoveToNextRound(string goalName)
     {
         IncrementScoreBasedOnGoal(goalName);
-        EndGameIfWinner();
+        FinishGameIfWinner();
         ResetRound();
     }
     private void IncrementScoreBasedOnGoal(string goalName)
@@ -55,7 +55,7 @@ public class GameController : MonoBehaviour
             rightScoreLabel.text = GameData.player2Score.ToString();
         }
     }
-    private void EndGameIfWinner()
+    private void FinishGameIfWinner()
     {
         if (GameData.player1Score == GameData.winningScore ||
             GameData.player2Score == GameData.winningScore)

--- a/Assets/Code/Controllers/GameController.cs
+++ b/Assets/Code/Controllers/GameController.cs
@@ -22,9 +22,6 @@ public class GameController : MonoBehaviour
         ballController = GameObject.Find("Ball").GetComponent<BallController>();
         player1Controller = GameObject.Find(player1PaddleName).GetComponent<PlayerController>();
         player2Controller = GameObject.Find(player2PaddleName).GetComponent<AiController>();
-
-        leftScoreLabel = GameObject.Find("LeftPlayerScore").GetComponent<TMPro.TextMeshProUGUI>();
-        rightScoreLabel = GameObject.Find("RightPlayerScore").GetComponent<TMPro.TextMeshProUGUI>();
     }
 
     void OnEnable()
@@ -35,24 +32,32 @@ public class GameController : MonoBehaviour
     {
         GameEvents.onVerticalWallHit.RemoveListener(MoveToNextRound);
     }
-
     public void MoveToNextRound(string goalName)
     {
+        ResetRound();
         IncrementScoreBasedOnGoal(goalName);
         FinishGameIfWinner();
-        ResetRound();
+    }
+
+    private void ResetRound()
+    {
+        ballController.Reset();
+        player1Controller.Reset();
+        player2Controller.Reset();
     }
     private void IncrementScoreBasedOnGoal(string goalName)
     {
         if (goalName == player1OpposingGoalName)
         {
             GameData.player1Score += 1;
-            leftScoreLabel.text = GameData.player1Score.ToString();
         }
         else if (goalName == player2OpposingGoalName)
         {
             GameData.player2Score += 1;
-            rightScoreLabel.text = GameData.player2Score.ToString();
+        }
+        else
+        {
+            Debug.LogError("Goal name '" + goalName + "' does not match registered goal names");
         }
     }
     private void FinishGameIfWinner()
@@ -62,11 +67,5 @@ public class GameController : MonoBehaviour
         {
             GameScenes.Load("EndMenu");
         }
-    }
-    private void ResetRound()
-    {
-        ballController.Reset();
-        player1Controller.Reset();
-        player2Controller.Reset();
     }
 }

--- a/Assets/Code/Controllers/GameController.cs
+++ b/Assets/Code/Controllers/GameController.cs
@@ -12,9 +12,6 @@ public class GameController : MonoBehaviour
     private PlayerController player1Controller;
     private AiController player2Controller;
 
-    private TMPro.TextMeshProUGUI leftScoreLabel;
-    private TMPro.TextMeshProUGUI rightScoreLabel;
-
     void Start()
     {
         GameData.Init();
@@ -34,12 +31,13 @@ public class GameController : MonoBehaviour
     }
     public void MoveToNextRound(string goalName)
     {
-        ResetRound();
+        ResetMovingObjects();
         IncrementScoreBasedOnGoal(goalName);
-        FinishGameIfWinner();
+        LoadSceneIfWinningScore("EndMenu");
+        GameEvents.onScoreChanged.Invoke();
     }
 
-    private void ResetRound()
+    private void ResetMovingObjects()
     {
         ballController.Reset();
         player1Controller.Reset();
@@ -60,12 +58,12 @@ public class GameController : MonoBehaviour
             Debug.LogError("Goal name '" + goalName + "' does not match registered goal names");
         }
     }
-    private void FinishGameIfWinner()
+    private void LoadSceneIfWinningScore(string sceneName)
     {
         if (GameData.player1Score == GameData.winningScore ||
             GameData.player2Score == GameData.winningScore)
         {
-            GameScenes.Load("EndMenu");
+            GameScenes.Load(sceneName);
         }
     }
 }

--- a/Assets/Code/Controllers/UiController.cs
+++ b/Assets/Code/Controllers/UiController.cs
@@ -1,0 +1,33 @@
+﻿using UnityEngine;
+
+public class UiController : MonoBehaviour
+{
+    public string leftScoreLabelName;
+    public string rightScoreLabelName;
+    private TMPro.TextMeshProUGUI leftScoreLabel;
+    private TMPro.TextMeshProUGUI rightScoreLabel;
+
+    void Start()
+    {
+        leftScoreLabel = GameObject.Find(leftScoreLabelName).GetComponent<TMPro.TextMeshProUGUI>();
+        rightScoreLabel = GameObject.Find(rightScoreLabelName).GetComponent<TMPro.TextMeshProUGUI>();
+    }
+    void Update()
+    {
+
+    }
+
+    void OnEnable()
+    {
+        GameEvents.onScoreChanged.AddListener(UpdateScore);
+    }
+    void OnDisable()
+    {
+        GameEvents.onScoreChanged.RemoveListener(UpdateScore);
+    }
+    public void UpdateScore()
+    {
+        leftScoreLabel.text = GameData.player1Score.ToString();
+        rightScoreLabel.text = GameData.player2Score.ToString();
+    }
+}

--- a/Assets/Code/Controllers/UiController.cs
+++ b/Assets/Code/Controllers/UiController.cs
@@ -4,6 +4,7 @@ public class UiController : MonoBehaviour
 {
     public string leftScoreLabelName;
     public string rightScoreLabelName;
+
     private TMPro.TextMeshProUGUI leftScoreLabel;
     private TMPro.TextMeshProUGUI rightScoreLabel;
 
@@ -11,10 +12,6 @@ public class UiController : MonoBehaviour
     {
         leftScoreLabel = GameObject.Find(leftScoreLabelName).GetComponent<TMPro.TextMeshProUGUI>();
         rightScoreLabel = GameObject.Find(rightScoreLabelName).GetComponent<TMPro.TextMeshProUGUI>();
-    }
-    void Update()
-    {
-
     }
 
     void OnEnable()

--- a/Assets/Code/Controllers/UiController.cs.meta
+++ b/Assets/Code/Controllers/UiController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d28c07453915bd2498843bb36cac909d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/Data/GameEvents.cs
+++ b/Assets/Code/Data/GameEvents.cs
@@ -9,8 +9,8 @@ public static class GameEvents
 {
     public static StringEvent onPaddleHit = new StringEvent();
     public static StringEvent onVerticalWallHit = new StringEvent();
+    public static UnityEvent onScoreChanged = new UnityEvent();
 
-    public static StringEvent onStartGame  = new StringEvent();
     public static StringEvent onPauseGame  = new StringEvent();
     public static UnityEvent  onFinishGame = new UnityEvent();
     public static StringEvent onQuitGame   = new StringEvent();

--- a/Assets/Code/Data/GameEvents.cs
+++ b/Assets/Code/Data/GameEvents.cs
@@ -12,6 +12,6 @@ public static class GameEvents
 
     public static StringEvent onStartGame  = new StringEvent();
     public static StringEvent onPauseGame  = new StringEvent();
-    public static StringEvent onFinishGame = new StringEvent();
+    public static UnityEvent  onFinishGame = new UnityEvent();
     public static StringEvent onQuitGame   = new StringEvent();
 }

--- a/Assets/Code/Data/GameEvents.cs
+++ b/Assets/Code/Data/GameEvents.cs
@@ -9,4 +9,9 @@ public static class GameEvents
 {
     public static StringEvent onPaddleHit = new StringEvent();
     public static StringEvent onVerticalWallHit = new StringEvent();
+
+    public static StringEvent onStartGame  = new StringEvent();
+    public static StringEvent onPauseGame  = new StringEvent();
+    public static StringEvent onFinishGame = new StringEvent();
+    public static StringEvent onQuitGame   = new StringEvent();
 }

--- a/Assets/Code/Data/GameEvents.cs
+++ b/Assets/Code/Data/GameEvents.cs
@@ -7,11 +7,7 @@ public class StringEvent : UnityEvent<string> { }
 // note events are triggered and handled programmatically (via listeners and invocations)
 public static class GameEvents
 {
-    public static StringEvent onPaddleHit = new StringEvent();
+    public static StringEvent onPaddleHit       = new StringEvent();
     public static StringEvent onVerticalWallHit = new StringEvent();
-    public static UnityEvent onScoreChanged = new UnityEvent();
-
-    public static StringEvent onPauseGame  = new StringEvent();
-    public static UnityEvent  onFinishGame = new UnityEvent();
-    public static StringEvent onQuitGame   = new StringEvent();
+    public static UnityEvent  onScoreChanged    = new UnityEvent();
 }

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -1090,6 +1090,7 @@ RectTransform:
   - {fileID: 5411584271149002186}
   - {fileID: 1513939283}
   - {fileID: 5411584272390542244}
+  - {fileID: 1971746184}
   m_Father: {fileID: 432980703}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1123,6 +1124,41 @@ MonoBehaviour:
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
+--- !u!1 &1971746183
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1971746184}
+  m_Layer: 5
+  m_Name: ScoreUpdater
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1971746184
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971746183}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1627022174}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &1974708889
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1857,7 +1893,7 @@ GameObject:
   m_TagString: TextLabel
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!114 &5411584271149002188
 MonoBehaviour:
@@ -1915,7 +1951,7 @@ GameObject:
   m_TagString: TextLabel
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 4294967295
+  m_StaticEditorFlags: 0
   m_IsActive: 1
 --- !u!114 &5411584272390542246
 MonoBehaviour:

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -1829,7 +1829,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5411584271149002187}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 103.00431}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 0}
   m_Children: []
   m_Father: {fileID: 1627022174}
@@ -1887,7 +1887,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5411584272390542245}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 103.00431}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 0}
   m_Children: []
   m_Father: {fileID: 1627022174}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -326,7 +326,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &117259443
 MonoBehaviour:
@@ -640,7 +640,7 @@ RectTransform:
   - {fileID: 1430003661}
   - {fileID: 1627022174}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -697,7 +697,7 @@ PrefabInstance:
     - target: {fileID: 10405006053755535, guid: 2d2aa87f09491f04e98c4e1eda24c12d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 10405006053755535, guid: 2d2aa87f09491f04e98c4e1eda24c12d,
         type: 3}
@@ -716,6 +716,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2d2aa87f09491f04e98c4e1eda24c12d, type: 3}
+--- !u!1 &674523726
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 674523727}
+  - component: {fileID: 674523728}
+  m_Layer: 0
+  m_Name: UiController
+  m_TagString: Scripter
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &674523727
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 674523726}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &674523728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 674523726}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d28c07453915bd2498843bb36cac909d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  leftScoreLabelName: LeftPlayerScore
+  rightScoreLabelName: RightPlayerScore
 --- !u!1 &830990819 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8734476180867663125, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
@@ -924,7 +969,7 @@ PrefabInstance:
     - target: {fileID: 7617027791629370971, guid: c8dbfa0f129a8e84e951632cab7d6425,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 7617027791629370971, guid: c8dbfa0f129a8e84e951632cab7d6425,
         type: 3}
@@ -1204,7 +1249,7 @@ PrefabInstance:
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
@@ -1298,7 +1343,7 @@ PrefabInstance:
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
@@ -2136,7 +2181,7 @@ PrefabInstance:
     - target: {fileID: 5853589860258734046, guid: b5b0c2548e710314e882c4b1428eb985,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5853589860258734046, guid: b5b0c2548e710314e882c4b1428eb985,
         type: 3}


### PR DESCRIPTION
# Add onScoreChanged event with associated ui controller
Follow up to the [first half](https://github.com/jeffreypersons/Pong/pull/33) of the issue [add goal and scoring events](https://github.com/jeffreypersons/Pong/issues/27).

## Details
Adds parameter-less static event `onScoreChanged`
* Invoked in game controller class after incrementing the score at the end of the `MoveToNextRound` method
* Handled in new `UiController` script, which updates the score labels (whose references were previously held in the `GameController` class)