### PR TITLE
Increase ball and paddle size

### DIFF
--- a/Assets/Code/Controllers/BallController.cs
+++ b/Assets/Code/Controllers/BallController.cs
@@ -7,7 +7,7 @@ public class BallController : MonoBehaviour
 
     private Vector2 initialPosition;
     private Rigidbody2D ballBody;
-    private BoxCollider2D ballCollider;
+    private Collider2D ballCollider;
 
     public void Reset()
     {
@@ -26,8 +26,7 @@ public class BallController : MonoBehaviour
     {
         if (collision.gameObject.CompareTag("Paddle"))
         {
-            ballBody.velocity = ballSpeed *
-                ComputeBounceDirection(ballBody.position, ballCollider, collision.rigidbody.position, collision.collider);
+            ballBody.velocity = ballSpeed * ComputeBounceDirection(ballCollider.bounds, collision.collider.bounds);
             GameEvents.onPaddleHit.Invoke(collision.gameObject.name);
         }
         if (collision.gameObject.CompareTag("HorizontalWall"))
@@ -40,11 +39,10 @@ public class BallController : MonoBehaviour
         }
     }
 
-    private static Vector2 ComputeBounceDirection(Vector2 ballPosition, Collider2D ballCollider,
-        Vector2 paddlePosition, Collider2D paddleCollider)
+    private static Vector2 ComputeBounceDirection(Bounds ballBounds, Bounds paddleBounds)
     {
-        float invertedXDirection = ballPosition.x + paddlePosition.x > 0 ? -1 : 1;
-        float offsetFromPaddleCenterToBall = (ballPosition.y - paddlePosition.y) / paddleCollider.bounds.size.y;
+        float invertedXDirection = ballBounds.center.x + paddleBounds.center.x > 0 ? -1 : 1;
+        float offsetFromPaddleCenterToBall = (ballBounds.center.y - paddleBounds.center.y) / paddleBounds.size.y;
         return new Vector2(invertedXDirection, offsetFromPaddleCenterToBall).normalized;
     }
 }

--- a/Assets/Code/Controllers/BallController.cs
+++ b/Assets/Code/Controllers/BallController.cs
@@ -6,17 +6,19 @@ public class BallController : MonoBehaviour
     public Vector2 initialDirection;
 
     private Vector2 initialPosition;
-    private Rigidbody2D ball;
+    private Rigidbody2D ballBody;
+    private BoxCollider2D ballCollider;
 
     public void Reset()
     {
-        ball.position = initialPosition;
-        ball.velocity = ballSpeed * initialDirection;
+        ballBody.position = initialPosition;
+        ballBody.velocity = ballSpeed * initialDirection;
     }
     void Start()
     {
-        ball = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
-        initialPosition = ball.position;
+        ballBody = GameObject.Find("Ball").GetComponent<Rigidbody2D>();
+        ballCollider = GameObject.Find("Ball").GetComponent<BoxCollider2D>();
+        initialPosition = ballBody.position;
         Reset();
     }
 
@@ -24,7 +26,8 @@ public class BallController : MonoBehaviour
     {
         if (collision.gameObject.CompareTag("Paddle"))
         {
-            ball.velocity = ballSpeed * ComputeBounceDirection(ball.position, collision.rigidbody.position, collision.collider);
+            ballBody.velocity = ballSpeed *
+                ComputeBounceDirection(ballBody.position, ballCollider, collision.rigidbody.position, collision.collider);
             GameEvents.onPaddleHit.Invoke(collision.gameObject.name);
         }
         if (collision.gameObject.CompareTag("HorizontalWall"))
@@ -37,10 +40,11 @@ public class BallController : MonoBehaviour
         }
     }
 
-    private Vector2 ComputeBounceDirection(Vector2 ballPosition, Vector2 paddlePosition, Collider2D paddleCollider)
+    private static Vector2 ComputeBounceDirection(Vector2 ballPosition, Collider2D ballCollider,
+        Vector2 paddlePosition, Collider2D paddleCollider)
     {
-        float invertedXDirection = ballPosition.x - paddlePosition.x > 0 ? -1 : 1;
-        float offsetFromPaddleCenterToBall = (ball.position.y - paddlePosition.y) / paddleCollider.bounds.size.y;
+        float invertedXDirection = ballPosition.x + paddlePosition.x > 0 ? -1 : 1;
+        float offsetFromPaddleCenterToBall = (ballPosition.y - paddlePosition.y) / paddleCollider.bounds.size.y;
         return new Vector2(invertedXDirection, offsetFromPaddleCenterToBall).normalized;
     }
 }

--- a/Assets/Prefabs/paddle.prefab
+++ b/Assets/Prefabs/paddle.prefab
@@ -28,7 +28,7 @@ Transform:
   m_GameObject: {fileID: 8734476180867663125}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.9, y: 1.1, z: 1}
+  m_LocalScale: {x: 0.75, y: 1.75, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0

--- a/Assets/Prefabs/paddle.prefab
+++ b/Assets/Prefabs/paddle.prefab
@@ -28,7 +28,7 @@ Transform:
   m_GameObject: {fileID: 8734476180867663125}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.75, y: 1.75, z: 1}
+  m_LocalScale: {x: 1.15, y: 1.75, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -411,7 +411,7 @@ PrefabInstance:
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -22.5
+      value: -21
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
@@ -499,7 +499,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   paddleName: LeftPaddle
-  paddleSpeed: 50
+  paddleSpeed: 60
   inputAxisName: Vertical
 --- !u!20 &1013986196 stripped
 Camera:
@@ -665,7 +665,7 @@ PrefabInstance:
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 22.5
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
@@ -753,7 +753,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   paddleName: RightPaddle
-  paddleSpeed: 25
+  paddleSpeed: 35
   randomSlowDownVariance: 0.35
   responseTime: 0.4
 --- !u!1001 &6782805226661251337

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -295,7 +295,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: afdec29fe794c7846b5b1255117d67ac, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ballSpeed: 50
+  ballSpeed: 60
   initialDirection: {x: 1, y: 0}
 --- !u!1 &674523726
 GameObject:
@@ -514,7 +514,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   paddleName: LeftPaddle
-  paddleSpeed: 60
+  paddleSpeed: 50
   inputAxisName: Vertical
 --- !u!20 &1013986196 stripped
 Camera:
@@ -773,10 +773,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   paddleName: RightPaddle
-  paddleSpeed: 35
-  randomSlowDownVariance: 0.35
+  paddleSpeed: 37.5
+  randomSlowDownVariance: 0.3
   maxToleratedDistanceFromBall: 0.1
-  responseTime: 0.4
+  responseTime: 0.375
 --- !u!1001 &6782805226661251337
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -230,10 +230,40 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7617027791629370971, guid: c8dbfa0f129a8e84e951632cab7d6425,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7617027791629370971, guid: c8dbfa0f129a8e84e951632cab7d6425,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
     - target: {fileID: 7617027791629370972, guid: c8dbfa0f129a8e84e951632cab7d6425,
         type: 3}
       propertyPath: m_Name
       value: Ball
+      objectReference: {fileID: 0}
+    - target: {fileID: 7617027791629370974, guid: c8dbfa0f129a8e84e951632cab7d6425,
+        type: 3}
+      propertyPath: m_Interpolate
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7617027791629370974, guid: c8dbfa0f129a8e84e951632cab7d6425,
+        type: 3}
+      propertyPath: m_Constraints
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7617027791629370974, guid: c8dbfa0f129a8e84e951632cab7d6425,
+        type: 3}
+      propertyPath: m_Simulated
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7617027791629370974, guid: c8dbfa0f129a8e84e951632cab7d6425,
+        type: 3}
+      propertyPath: m_AngularDrag
+      value: 0.05
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c8dbfa0f129a8e84e951632cab7d6425, type: 3}
@@ -381,7 +411,7 @@ PrefabInstance:
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -20
+      value: -22.5
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
@@ -437,6 +467,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_BodyType
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8734476180867663123, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
+        type: 3}
+      propertyPath: m_Constraints
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663125, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
@@ -630,7 +665,7 @@ PrefabInstance:
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 20
+      value: 22.5
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663120, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
@@ -687,6 +722,11 @@ PrefabInstance:
       propertyPath: m_BodyType
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8734476180867663123, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
+        type: 3}
+      propertyPath: m_Constraints
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663125, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
       propertyPath: m_Name
@@ -713,9 +753,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   paddleName: RightPaddle
-  paddleSpeed: 22.5
-  randomSlowDownVariance: 0.4
-  responseTime: 0.45
+  paddleSpeed: 25
+  randomSlowDownVariance: 0.35
+  responseTime: 0.4
 --- !u!1001 &6782805226661251337
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -265,6 +265,16 @@ PrefabInstance:
       propertyPath: m_AngularDrag
       value: 0.05
       objectReference: {fileID: 0}
+    - target: {fileID: 7617027791629370974, guid: c8dbfa0f129a8e84e951632cab7d6425,
+        type: 3}
+      propertyPath: m_BodyType
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7617027791629370974, guid: c8dbfa0f129a8e84e951632cab7d6425,
+        type: 3}
+      propertyPath: m_UseFullKinematicContacts
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c8dbfa0f129a8e84e951632cab7d6425, type: 3}
 --- !u!1 &226754537 stripped
@@ -472,6 +482,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Constraints
       value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8734476180867663123, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
+        type: 3}
+      propertyPath: m_UseFullKinematicContacts
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663125, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}
@@ -726,6 +741,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Constraints
       value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8734476180867663123, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
+        type: 3}
+      propertyPath: m_UseFullKinematicContacts
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8734476180867663125, guid: 9d0ad7303ce70c14b9c0d2e2239e6dff,
         type: 3}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -775,6 +775,7 @@ MonoBehaviour:
   paddleName: RightPaddle
   paddleSpeed: 35
   randomSlowDownVariance: 0.35
+  maxToleratedDistanceFromBall: 0.1
   responseTime: 0.4
 --- !u!1001 &6782805226661251337
 PrefabInstance:


### PR DESCRIPTION
# Increase ball and paddle size
Increased the size of the moving objects, and adjusted things to match the new sizes.
* Balance paddle and ball speeds
* Include BOTH ball and paddle collider bounds as a step towards fixing bugging bounce directions for larger objects
* Use collider bounds for collisions instead of rigidbodies
* Increase paddle width so that hitting the ball from top is more viable
* Update collider physics properties
* Add distance tolerance to accomodate changes in sizes
Before when sizes were smaller, it wasn't as important to take the sizes into consideration during collisions, but upon increasing sizes of the ball and paddles...
I decided to add tolerance ranges for aligning with the balls to compensate for the extended paddle lengths