### PR TITLE
Encapsulate fields by changing to private but viewable in inspector

### DIFF
--- a/Assets/Code/Controllers/AiController.cs
+++ b/Assets/Code/Controllers/AiController.cs
@@ -4,10 +4,9 @@ using UnityEngine;
 
 public class AiController : MonoBehaviour
 {
-    [SerializeField] private float paddleSpeed;
-    [SerializeField] private float responseTime;
-    [SerializeField] private float randomSlowDownVariance;
-    [SerializeField] private float minVerticalDistanceBeforeMoving;
+    [SerializeField] private float paddleSpeed  = default;
+    [SerializeField] private float responseTime = default;
+    [SerializeField] private float minVerticalDistanceBeforeMoving = default;
 
     private Rigidbody2D paddleBody;
     private BoxCollider2D paddleCollider;

--- a/Assets/Code/Controllers/AiController.cs
+++ b/Assets/Code/Controllers/AiController.cs
@@ -4,10 +4,10 @@ using UnityEngine;
 
 public class AiController : MonoBehaviour
 {
-    public float paddleSpeed;
-    public float responseTime;
-    public float randomSlowDownVariance;
-    public float minVerticalDistanceBeforeMoving;
+    [SerializeField] private float paddleSpeed;
+    [SerializeField] private float responseTime;
+    [SerializeField] private float randomSlowDownVariance;
+    [SerializeField] private float minVerticalDistanceBeforeMoving;
 
     private Rigidbody2D paddleBody;
     private BoxCollider2D paddleCollider;

--- a/Assets/Code/Controllers/BallController.cs
+++ b/Assets/Code/Controllers/BallController.cs
@@ -3,8 +3,8 @@
 
 public class BallController : MonoBehaviour
 {
-    [SerializeField] private float ballSpeed;
-    [SerializeField] private Vector2 initialDirection;
+    [SerializeField] private float   ballSpeed        = default;
+    [SerializeField] private Vector2 initialDirection = default;
 
     private Vector2 initialPosition;
     private Rigidbody2D ballBody;

--- a/Assets/Code/Controllers/BallController.cs
+++ b/Assets/Code/Controllers/BallController.cs
@@ -3,8 +3,8 @@
 
 public class BallController : MonoBehaviour
 {
-    public float ballSpeed;
-    public Vector2 initialDirection;
+    [SerializeField] private float ballSpeed;
+    [SerializeField] private Vector2 initialDirection;
 
     private Vector2 initialPosition;
     private Rigidbody2D ballBody;

--- a/Assets/Code/Controllers/GameRoundController.cs
+++ b/Assets/Code/Controllers/GameRoundController.cs
@@ -7,12 +7,12 @@ public class GameRoundController : MonoBehaviour
     private RecordedScore recordedScore;
 
     // todo: replace with Paddle/MoveController interfaces, and use like `MoveController.Reset()`
-    [SerializeField] private GameObject ball;
-    [SerializeField] private GameObject playerPaddle;
-    [SerializeField] private GameObject aiPaddle;
+    [SerializeField] private GameObject ball         = default;
+    [SerializeField] private GameObject playerPaddle = default;
+    [SerializeField] private GameObject aiPaddle     = default;
 
-    [SerializeField] private GameObject leftGoal;
-    [SerializeField] private GameObject rightGoal;
+    [SerializeField] private GameObject leftGoal     = default;
+    [SerializeField] private GameObject rightGoal    = default;
 
     void Awake()
     {

--- a/Assets/Code/Controllers/GameRoundController.cs
+++ b/Assets/Code/Controllers/GameRoundController.cs
@@ -7,12 +7,12 @@ public class GameRoundController : MonoBehaviour
     private RecordedScore recordedScore;
 
     // todo: replace with Paddle/MoveController interfaces, and use like `MoveController.Reset()`
-    public GameObject ball;
-    public GameObject playerPaddle;
-    public GameObject aiPaddle;
+    [SerializeField] private GameObject ball;
+    [SerializeField] private GameObject playerPaddle;
+    [SerializeField] private GameObject aiPaddle;
 
-    public GameObject leftGoal;
-    public GameObject rightGoal;
+    [SerializeField] private GameObject leftGoal;
+    [SerializeField] private GameObject rightGoal;
 
     void Awake()
     {

--- a/Assets/Code/Controllers/IngameHudController.cs
+++ b/Assets/Code/Controllers/IngameHudController.cs
@@ -4,9 +4,9 @@ using UnityEngine.UI;
 
 public class IngameHudController : MonoBehaviour
 {
-    public Button pauseButton;
-    public TMPro.TextMeshProUGUI leftScoreLabel;
-    public TMPro.TextMeshProUGUI rightScoreLabel;
+    [SerializeField] private Button pauseButton;
+    [SerializeField] private TMPro.TextMeshProUGUI leftScoreLabel;
+    [SerializeField] private TMPro.TextMeshProUGUI rightScoreLabel;
 
     private RecordedScore lastRecordedScore;
 

--- a/Assets/Code/Controllers/IngameHudController.cs
+++ b/Assets/Code/Controllers/IngameHudController.cs
@@ -4,9 +4,9 @@ using UnityEngine.UI;
 
 public class IngameHudController : MonoBehaviour
 {
-    [SerializeField] private Button pauseButton;
-    [SerializeField] private TMPro.TextMeshProUGUI leftScoreLabel;
-    [SerializeField] private TMPro.TextMeshProUGUI rightScoreLabel;
+    [SerializeField] private Button pauseButton = default;
+    [SerializeField] private TMPro.TextMeshProUGUI leftScoreLabel  = default;
+    [SerializeField] private TMPro.TextMeshProUGUI rightScoreLabel = default;
 
     private RecordedScore lastRecordedScore;
 

--- a/Assets/Code/Controllers/IngameMenuController.cs
+++ b/Assets/Code/Controllers/IngameMenuController.cs
@@ -5,13 +5,13 @@ using UnityEngine.UI;
 
 public class IngameMenuController : MonoBehaviour
 {
-    [SerializeField] private GameObject ingameMenu;
-    [SerializeField] private TMPro.TextMeshProUGUI title;
-    [SerializeField] private TMPro.TextMeshProUGUI subtitle;
-    [SerializeField] private Button resumeButton;
-    [SerializeField] private Button mainMenuButton;
-    [SerializeField] private Button restartButton;
-    [SerializeField] private Button quitButton;
+    [SerializeField] private GameObject ingameMenu = default;
+    [SerializeField] private TMPro.TextMeshProUGUI title    = default;
+    [SerializeField] private TMPro.TextMeshProUGUI subtitle = default;
+    [SerializeField] private Button resumeButton   = default;
+    [SerializeField] private Button mainMenuButton = default;
+    [SerializeField] private Button restartButton  = default;
+    [SerializeField] private Button quitButton     = default;
 
     private List<Button> buttonsToHideWhenActive;
     private List<TMPro.TextMeshProUGUI> labelsToHideWhenActive;

--- a/Assets/Code/Controllers/IngameMenuController.cs
+++ b/Assets/Code/Controllers/IngameMenuController.cs
@@ -5,13 +5,13 @@ using UnityEngine.UI;
 
 public class IngameMenuController : MonoBehaviour
 {
-    public GameObject ingameMenu;
-    public TMPro.TextMeshProUGUI title;
-    public TMPro.TextMeshProUGUI subtitle;
-    public Button resumeButton;
-    public Button mainMenuButton;
-    public Button restartButton;
-    public Button quitButton;
+    [SerializeField] private GameObject ingameMenu;
+    [SerializeField] private TMPro.TextMeshProUGUI title;
+    [SerializeField] private TMPro.TextMeshProUGUI subtitle;
+    [SerializeField] private Button resumeButton;
+    [SerializeField] private Button mainMenuButton;
+    [SerializeField] private Button restartButton;
+    [SerializeField] private Button quitButton;
 
     private List<Button> buttonsToHideWhenActive;
     private List<TMPro.TextMeshProUGUI> labelsToHideWhenActive;

--- a/Assets/Code/Controllers/MainMenuController.cs
+++ b/Assets/Code/Controllers/MainMenuController.cs
@@ -5,11 +5,11 @@ using UnityEngine.UI;
 
 public class MainMenuController : MonoBehaviour
 {
-    [SerializeField] private Button startButton;
-    [SerializeField] private Button settingsButton;
-    [SerializeField] private Button aboutButton;
-    [SerializeField] private Button quitButton;
-    [SerializeField] private SubmainMenuController submenuController;
+    [SerializeField] private Button startButton    = default;
+    [SerializeField] private Button settingsButton = default;
+    [SerializeField] private Button aboutButton    = default;
+    [SerializeField] private Button quitButton     = default;
+    [SerializeField] private SubmainMenuController submenuController = default;
 
     private List<Button> buttonsToHideWhenActive;
     private List<TMPro.TextMeshProUGUI> labelsToHideWhenActive;

--- a/Assets/Code/Controllers/PlayerController.cs
+++ b/Assets/Code/Controllers/PlayerController.cs
@@ -3,8 +3,8 @@
 
 public class PlayerController : MonoBehaviour
 {
-    public float paddleSpeed;
-    public string inputAxisName;
+    [SerializeField] private float paddleSpeed;
+    [SerializeField] private string inputAxisName;
 
     private Vector2 initialPosition;
     private Vector2 inputVelocity;

--- a/Assets/Code/Controllers/PlayerController.cs
+++ b/Assets/Code/Controllers/PlayerController.cs
@@ -3,8 +3,8 @@
 
 public class PlayerController : MonoBehaviour
 {
-    [SerializeField] private float paddleSpeed;
-    [SerializeField] private string inputAxisName;
+    [SerializeField] private float  paddleSpeed   = default;
+    [SerializeField] private string inputAxisName = default;
 
     private Vector2 initialPosition;
     private Vector2 inputVelocity;
@@ -12,7 +12,7 @@ public class PlayerController : MonoBehaviour
 
     public void Reset()
     {
-        inputVelocity = Vector2.zero;
+        inputVelocity       = Vector2.zero;
         paddleBody.velocity = inputVelocity;
         paddleBody.position = initialPosition;
     }

--- a/Assets/Code/Controllers/SliderSettingController.cs
+++ b/Assets/Code/Controllers/SliderSettingController.cs
@@ -5,14 +5,14 @@ using UnityEngine.UI;
 [ExecuteAlways]
 public class SliderSettingController : MonoBehaviour
 {
-    [SerializeField] private string description;
-    [SerializeField] private string numberSuffix;
-    [SerializeField] private string defaultValue;
-    [SerializeField] private string minValue;
-    [SerializeField] private string maxValue;
+    [SerializeField] private string description  = default;
+    [SerializeField] private string numberSuffix = default;
+    [SerializeField] private string defaultValue = default;
+    [SerializeField] private string minValue     = default;
+    [SerializeField] private string maxValue     = default;
 
-    [SerializeField] private TMPro.TextMeshProUGUI label;
-    [SerializeField] private Slider slider;
+    [SerializeField] private TMPro.TextMeshProUGUI label = default;
+    [SerializeField] private Slider slider = default;
 
     public float SliderValue    { get { return slider.value;    } }
     public float MinSliderValue { get { return slider.minValue; } }

--- a/Assets/Code/Controllers/SubmainMenuController.cs
+++ b/Assets/Code/Controllers/SubmainMenuController.cs
@@ -12,14 +12,14 @@ public class SubmainMenuController : MonoBehaviour
     private Action actionOnPanelOpen;
     private Action actionOnPanelClose;
 
-    [SerializeField] private GameObject startPanel;
-    [SerializeField] private GameObject settingsPanel;
-    [SerializeField] private GameObject aboutPanel;
+    [SerializeField] private GameObject startPanel    = default;
+    [SerializeField] private GameObject settingsPanel = default;
+    [SerializeField] private GameObject aboutPanel    = default;
 
-    [SerializeField] private SliderSettingController difficultySetting;
-    [SerializeField] private SliderSettingController numberOfGoalsSetting;
-    [SerializeField] private SliderSettingController soundVolumeSetting;
-    [SerializeField] private SliderSettingController musicVolumeSetting;
+    [SerializeField] private SliderSettingController difficultySetting    = default;
+    [SerializeField] private SliderSettingController numberOfGoalsSetting = default;
+    [SerializeField] private SliderSettingController soundVolumeSetting   = default;
+    [SerializeField] private SliderSettingController musicVolumeSetting   = default;
 
     void OnEnable()
     {

--- a/Assets/Code/Controllers/SubmainMenuController.cs
+++ b/Assets/Code/Controllers/SubmainMenuController.cs
@@ -43,7 +43,6 @@ public class SubmainMenuController : MonoBehaviour
             musicVolume:     (int)musicVolumeSetting.SliderValue
         );
     }
-
     private void DeactivePanels()
     {
         startPanel.SetActive(false);
@@ -53,7 +52,7 @@ public class SubmainMenuController : MonoBehaviour
 
     private void OpenPanel(GameObject submenuPanel)
     {
-        if (MathUtils.CountTrueValues(startPanel.active, settingsPanel.active, aboutPanel.active) != 0)
+        if (startPanel.activeInHierarchy || settingsPanel.activeInHierarchy || aboutPanel.activeInHierarchy)
         {
             Debug.LogError($"Cannot open {submenuPanel.name}, since only one sub-mainmenu panel can be active at a time.");
         }

--- a/Assets/Code/Data/GameEventCenter.cs
+++ b/Assets/Code/Data/GameEventCenter.cs
@@ -12,7 +12,7 @@ public static class GameEventCenter
     public static GameEvent<RecordedScore> scoreChange                = new GameEvent<RecordedScore>();
     public static GameEvent<PaddleZoneIntersectInfo> zoneIntersection = new GameEvent<PaddleZoneIntersectInfo>();
 
-    public static GameEvent<GameSettings> startNewGame        = new GameEvent<GameSettings>();
+    public static GameEvent<GameSettings>     startNewGame        = new GameEvent<GameSettings>();
     public static GameEvent<RecordedScore>    pauseGame           = new GameEvent<RecordedScore>();
     public static GameEvent<string>           resumeGame          = new GameEvent<string>();
     public static GameEvent<string>           gotoMainMenu        = new GameEvent<string>();

--- a/Assets/Code/Data/PaddleZoneIntersectInfo.cs
+++ b/Assets/Code/Data/PaddleZoneIntersectInfo.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 
+
 // assumes directly vertical bounces are not velocity possible, and thus zones are never continually occupied!
 // (unless of course the initial ball velocity is set that way!)
 public class PaddleZoneIntersectInfo

--- a/Assets/Code/Data/RecordedScore.cs
+++ b/Assets/Code/Data/RecordedScore.cs
@@ -1,5 +1,4 @@
-﻿using UnityEngine;
-
+﻿
 
 public class RecordedScore
 {

--- a/Assets/Code/Scripts/ExpandZoneToEncapsulatePaddle.cs
+++ b/Assets/Code/Scripts/ExpandZoneToEncapsulatePaddle.cs
@@ -4,7 +4,8 @@
 [ExecuteAlways]
 public class ExpandZoneToEncapsulatePaddle : MonoBehaviour
 {
-    [SerializeField] private float extraWidth;
+    [SerializeField] private float extraWidth = default;
+
     private BoxCollider2D zoneCollider;
     private BoxCollider2D paddleCollider;
 

--- a/Assets/Code/Scripts/ExpandZoneToEncapsulatePaddle.cs
+++ b/Assets/Code/Scripts/ExpandZoneToEncapsulatePaddle.cs
@@ -4,7 +4,7 @@
 [ExecuteAlways]
 public class ExpandZoneToEncapsulatePaddle : MonoBehaviour
 {
-    public float extraWidth;
+    [SerializeField] private float extraWidth;
     private BoxCollider2D zoneCollider;
     private BoxCollider2D paddleCollider;
 

--- a/Assets/Code/Tools/MathUtils.cs
+++ b/Assets/Code/Tools/MathUtils.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using UnityEngine;
 
 

--- a/Assets/Code/Tools/MathUtils.cs
+++ b/Assets/Code/Tools/MathUtils.cs
@@ -43,17 +43,4 @@ public static class MathUtils
         }
         return true;
     }
-
-    public static int CountTrueValues(params bool[] values)
-    {
-        int count = 0;
-        foreach (bool value in values)
-        {
-            if (value)
-            {
-                count++;
-            }
-        }
-        return count;
-    }
 }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.8f1
-m_EditorVersionWithRevision: 2019.3.8f1 (4ba98e9386ed)
+m_EditorVersion: 2019.3.9f1
+m_EditorVersionWithRevision: 2019.3.9f1 (e6e740a1c473)


### PR DESCRIPTION
# Encapsulate fields by changing to private but viewable in inspector
Addresses the issue [All fields editable in inspector marked as public at the expense of encapsulation](https://github.com/jeffreypersons/Paddle-Whacker/issues/74) by marking all said fields `private` with a `[serializefield]` annotation and inline assignment to `default` to avoid `unity's null warning 649`


specifically:
**_all_** public fields are changed from `public Foo foo` to `[serializefield] private Foo foo = default`