### PR TITLE
Fully disable resume button when ingame menu is displayed at the end of a match

### DIFF
--- a/Assets/Code/Controllers/IngameMenuController.cs
+++ b/Assets/Code/Controllers/IngameMenuController.cs
@@ -28,7 +28,7 @@ public class IngameMenuController : MonoBehaviour
         GameEventCenter.winningScoreReached.AddListener(OpenAsEndGameMenu);
 
         #if UNITY_WEBGL
-            GameObjectUtils.DisableButtonCompletely(quitButton);
+            GameObjectUtils.SetButtonActiveAndEnabled(quitButton, false);
         #endif
     }
     void OnDestroy()
@@ -70,7 +70,7 @@ public class IngameMenuController : MonoBehaviour
             GameObjectUtils.SetSpriteVisibility(spritesToHideWhenActive[i], hideBackground);
         }
         #if UNITY_WEBGL
-            GameObjectUtils.DisableButtonCompletely(quitButton);
+            GameObjectUtils.SetButtonActiveAndEnabled(quitButton, false);
         #endif
     }
 
@@ -79,7 +79,7 @@ public class IngameMenuController : MonoBehaviour
         title.text    = "Game Paused";
         subtitle.text = recordedScore.LeftPlayerScore.ToString() + " - " + recordedScore.RightPlayerScore.ToString();
 
-        resumeButton.enabled = true;
+        GameObjectUtils.SetButtonActiveAndEnabled(resumeButton, true);
         ToggleMenuVisibility(true);
     }
     private void OpenAsEndGameMenu(RecordedScore recordedScore)
@@ -87,7 +87,7 @@ public class IngameMenuController : MonoBehaviour
         title.text    = recordedScore.IsLeftPlayerWinning() ? "Game Won" : "Game Lost";
         subtitle.text = recordedScore.LeftPlayerScore.ToString() + " - " + recordedScore.RightPlayerScore.ToString();
 
-        resumeButton.enabled = false;
+        GameObjectUtils.SetButtonActiveAndEnabled(resumeButton, false);
         ToggleMenuVisibility(true);
     }
 

--- a/Assets/Code/Controllers/MainMenuController.cs
+++ b/Assets/Code/Controllers/MainMenuController.cs
@@ -24,7 +24,7 @@ public class MainMenuController : MonoBehaviour
         mainMenuPanelController.SetActionOnPanelClose(()   => ToggleMenuVisibility(false));
 
         #if UNITY_WEBGL
-            GameObjectUtils.DisableButtonCompletely(quitButton);
+            GameObjectUtils.SetButtonActiveAndEnabled(quitButton, false);
         #endif
     }
 
@@ -63,7 +63,7 @@ public class MainMenuController : MonoBehaviour
             GameObjectUtils.SetLabelVisibility(labelToHideWhenPanelIsOpen[i], hideBackground);
         }
         #if UNITY_WEBGL
-            GameObjectUtils.DisableButtonCompletely(quitButton);
+            GameObjectUtils.SetButtonActiveAndEnabled(quitButton, false);
         #endif
     }
 }

--- a/Assets/Code/Tools/GameObjectUtils.cs
+++ b/Assets/Code/Tools/GameObjectUtils.cs
@@ -4,7 +4,7 @@ using UnityEngine.Events;
 using UnityEngine.UI;
 
 
-// note that these methods use old style for loops so that the found value an be modified after return
+// note that these methods use old style for loops so that the found value CAN be modified after return
 public static class GameObjectUtils
 {
     public static void AddAutoUnsubscribeOnClickListenerToButton(Button button, System.Action onButtonClicked)
@@ -18,31 +18,27 @@ public static class GameObjectUtils
         };
         button.onClick.AddListener(handler);
     }
-    public static void DisableButtonCompletely(Button button)
-    {
-        button.enabled = false;
-        button.gameObject.SetActive(false);
-    }
 
-    // hides button WITHOUT disabling/setting-inactive
-    public static void SetButtonVisibility(Button button, bool isVisible)
+    public static void SetSpriteVisibility(SpriteRenderer spriteRenderer, bool isVisible)
     {
-        button.image.enabled = isVisible;
-        button.enabled = isVisible;
+        spriteRenderer.enabled = isVisible;
     }
     public static void SetLabelVisibility(TMPro.TextMeshProUGUI label, bool isVisible)
     {
         label.enabled = isVisible;
     }
-    public static void SetSpriteVisibility(SpriteRenderer spriteRenderer, bool isVisible)
+    public static void SetButtonVisibility(Button button, bool isVisible)
     {
-        spriteRenderer.enabled = isVisible;
+        button.enabled       = isVisible;
+        button.image.enabled = isVisible;
     }
-    public static void SetAlpha(SpriteRenderer renderer, float alphaLevel)
+    public static void SetButtonActiveAndEnabled(Button button, bool isActiveAndEnabled)
     {
-        Color color = renderer.color;
-        renderer.color = new Color(color.r, color.g, color.b, alphaLevel);
+        button.gameObject.SetActive(isActiveAndEnabled);
+        button.enabled       = isActiveAndEnabled;
+        button.image.enabled = isActiveAndEnabled;
     }
+
     // note: only fetches active gameObjects
     public static List<GameObject> FindAllObjectsWithTags(params string[] tags)
     {


### PR DESCRIPTION
# Fully disable resume button when ingame menu is displayed at the end of a match
Before, there was a bug in which the resume button would be visible but disabled, when the ingame menu displays the results at the end of a match.

This is a simple fix that adjusts the visibility AND active-state for all buttons when a button is not appropriate for the context (ie resume button fully-disabled when the ingamemenu displays end results, and also used for quit buttons being deactivated if the game is running via webgl).