### PR TITLE
Adjust text formatting to fit about panel properly without any overlapping text

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1309,8 +1309,18 @@ PrefabInstance:
       propertyPath: m_text
       value: "Tired by the lack of originality found in most 'hit the ball with a
         paddle' genre of 2d games, Jeff wondered how it could be improved on.\r\n\r\nTaking
-        those ideas, he came up with Paddle Whacker - a game that blends the vertical-only\r
+        those ideas, he came up with Paddle Whacker - a game that blends the vertical-only
         movement of Pong with an Air-Hockey inspired arena.\r"
+      objectReference: {fileID: 0}
+    - target: {fileID: 740860354179590475, guid: e0957000c32928f48a969036e7d1e599,
+        type: 3}
+      propertyPath: m_fontSizeMin
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 740860354179590475, guid: e0957000c32928f48a969036e7d1e599,
+        type: 3}
+      propertyPath: m_fontSizeMax
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 2176643592344231257, guid: e0957000c32928f48a969036e7d1e599,
         type: 3}


### PR DESCRIPTION
# Adjust text formatting to fit about panel properly without any overlapping text

Addresses bug in the main menu scene where [Line endings in the about summary are not rendered properly](https://github.com/jeffreypersons/Paddle-Whacker/issues/87) by simply adjusting the carriage returns and font size such that the text fits cleanly within the about panel.