### PR TITLE
Get rid of ai paddle tendency to miss hitting the ball by a small amount

### DIFF
--- a/Assets/Prefabs/AiPaddle.prefab
+++ b/Assets/Prefabs/AiPaddle.prefab
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d08e6e93e462d54c831f2f23873b9fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  paddleSpeedAtMaxDifficulty: 45
-  responseTimeAtMaxDifficulty: 0.25
+  paddleSpeedAtMaxDifficulty: 37.5
+  responseTimeAtMaxDifficulty: 0.325
   minVerticalDistanceBeforeMoving: 0.025
+  initialTimeDelayAfterReset: 0.125
   layersUsedWhenPredictingTrajectory:
     serializedVersion: 2
     m_Bits: 256

--- a/Assets/Prefabs/arena.prefab
+++ b/Assets/Prefabs/arena.prefab
@@ -42,6 +42,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5853589860258734046}
     m_Modifications:
+    - target: {fileID: 1924874970051057241, guid: c4cc2c28a50477d41bc52db5dff48010,
+        type: 3}
+      propertyPath: m_Offset.y
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1924874970051057241, guid: c4cc2c28a50477d41bc52db5dff48010,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 7
+      objectReference: {fileID: 0}
     - target: {fileID: 6551787347089147850, guid: c4cc2c28a50477d41bc52db5dff48010,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -122,6 +132,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 5853589860258734046}
     m_Modifications:
+    - target: {fileID: 1924874970051057241, guid: c4cc2c28a50477d41bc52db5dff48010,
+        type: 3}
+      propertyPath: m_Offset.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1924874970051057241, guid: c4cc2c28a50477d41bc52db5dff48010,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 7
+      objectReference: {fileID: 0}
     - target: {fileID: 6551787347089147850, guid: c4cc2c28a50477d41bc52db5dff48010,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -357,10 +377,35 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4440478279684549789, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4440478279684549789, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 7
+      objectReference: {fileID: 0}
     - target: {fileID: 6709989145214492952, guid: 5dc1f69ba836c1a4e8c64affc011c474,
         type: 3}
       propertyPath: m_Offset.x
-      value: -1.5
+      value: -4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6709989145214492952, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8665758789593376726, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8665758789593376726, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5dc1f69ba836c1a4e8c64affc011c474, type: 3}
@@ -436,6 +481,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4440478279684549789, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4440478279684549789, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6709989145214492952, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6709989145214492952, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 8665758789593376726, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8665758789593376726, guid: 5dc1f69ba836c1a4e8c64affc011c474,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5dc1f69ba836c1a4e8c64affc011c474, type: 3}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -701,6 +701,11 @@ PrefabInstance:
       propertyPath: m_Size.x
       value: 4.5
       objectReference: {fileID: 0}
+    - target: {fileID: 1129781707374916769, guid: d6f7c46cd823a224fa2d17fa7d6e69ed,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 49.14
+      objectReference: {fileID: 0}
     - target: {fileID: 1482564607410630762, guid: d6f7c46cd823a224fa2d17fa7d6e69ed,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -791,6 +796,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Size.x
       value: 4.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1129781707374916769, guid: d6f7c46cd823a224fa2d17fa7d6e69ed,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 49.14
       objectReference: {fileID: 0}
     - target: {fileID: 1482564607410630762, guid: d6f7c46cd823a224fa2d17fa7d6e69ed,
         type: 3}
@@ -1349,12 +1359,12 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 256875173, guid: 0173095caa3a77b4ebfecb9bd4d161d9, type: 3}
-      propertyPath: initialMovementDelayAfterReset
-      value: 0.075
+      propertyPath: paddleSpeedAtMaxDifficulty
+      value: 70
       objectReference: {fileID: 0}
     - target: {fileID: 256875173, guid: 0173095caa3a77b4ebfecb9bd4d161d9, type: 3}
-      propertyPath: initialTimeDelayAfterReset
-      value: 0.125
+      propertyPath: ResponseTimeAtMinDifficulty
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 4898979997282198361, guid: 0173095caa3a77b4ebfecb9bd4d161d9,
         type: 3}

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1295,6 +1295,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: StartPanel
       objectReference: {fileID: 0}
+    - target: {fileID: 7394248188617143330, guid: ce246366c2d147c40af4cfe64ad4e09d,
+        type: 3}
+      propertyPath: initialValue
+      value: 30
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ce246366c2d147c40af4cfe64ad4e09d, type: 3}
 --- !u!1001 &4423620729958631719


### PR DESCRIPTION
# Get rid of ai paddle tendency to miss hitting the ball by a small amount
Add special casing: if a predicted trajectory starts and ends within the ai paddle's vertical bounds, then randomize an offset no further than the ball's width.

This greatly improves on the ai improvements made earlier today in normalizing the ai behavior, to the point where there is not much more I can do short of adding a full aggression system. The Ai is pretty solid now.