### PR TITLE
Convert all slider value percentages as ratios between inspector-assigned min/max values

### DIFF
--- a/Assets/Code/Controllers/GameRoundController.cs
+++ b/Assets/Code/Controllers/GameRoundController.cs
@@ -35,7 +35,7 @@ public class GameRoundController : MonoBehaviour
         GameEventCenter.restartGame.RemoveListener(RestartGame);
     }
 
-    private void StartNewGame(GameSettings gameSettings)
+    private void StartNewGame(GameSettingsInfo gameSettings)
     {
         recordedScore = new RecordedScore(gameSettings.NumberOfGoals);
         aiPaddle.GetComponent<AiController>().SetDifficultyLevel(gameSettings.DifficultyLevel);

--- a/Assets/Code/Controllers/MainMenuPanelController.cs
+++ b/Assets/Code/Controllers/MainMenuPanelController.cs
@@ -33,13 +33,13 @@ public class MainMenuPanelController : MonoBehaviour
     public void SetActionOnPanelOpen(Action actionOnPanelOpen)     { this.actionOnPanelOpen  = actionOnPanelOpen;  }
     public void SetActionOnPanelClose(Action actionOnPanelClose)   { this.actionOnPanelClose = actionOnPanelClose; }
 
-    public GameSettings GetGameSettings()
+    public GameSettingsInfo GetGameSettings()
     {
-        return new GameSettings(
-            numberOfGoals:   (int)numberOfGoalsSetting.SliderValue,
-            difficultyLevel: (int)difficultySetting.SliderValue,
-            soundVolume:     (int)soundVolumeSetting.SliderValue,
-            musicVolume:     (int)musicVolumeSetting.SliderValue
+        return new GameSettingsInfo(
+            numberOfGoals:      (int)numberOfGoalsSetting.SliderValue,
+            difficultyPercent:  (int)difficultySetting.SliderValue,
+            soundVolumePercent: (int)soundVolumeSetting.SliderValue,
+            musicVolumePercent: (int)musicVolumeSetting.SliderValue
         );
     }
     private void DeactivePanels()

--- a/Assets/Code/Controllers/SoundEffectController.cs
+++ b/Assets/Code/Controllers/SoundEffectController.cs
@@ -4,7 +4,7 @@
 public class SoundEffectController : MonoBehaviour
 {
     private AudioSource audioSource;
-    private static float DEFAULT_MASTER_VOLUME = 0.5f;
+    private static float DEFAULT_MASTER_VOLUME = 0.25f;
 
     [SerializeField] private float volumeScaleWallHit    = default;
     [SerializeField] private float volumeScalePaddleHit  = default;
@@ -59,7 +59,7 @@ public class SoundEffectController : MonoBehaviour
     {
         audioSource.UnPause();
     }
-    private void SetMasterVolume(GameSettings gameSettings)
+    private void SetMasterVolume(GameSettingsInfo gameSettings)
     {
         audioSource.volume = gameSettings.SoundVolume / 100.0f;
     }

--- a/Assets/Code/Controllers/SoundTrackController.cs
+++ b/Assets/Code/Controllers/SoundTrackController.cs
@@ -4,7 +4,7 @@
 public class SoundTrackController : MonoBehaviour
 {
     private AudioSource track;
-    private static float DEFAULT_MASTER_VOLUME = 1.0f;
+    private static float DEFAULT_MASTER_VOLUME = 0.50f;
 
     void Awake()
     {
@@ -31,7 +31,7 @@ public class SoundTrackController : MonoBehaviour
         GameEventCenter.winningScoreReached.RemoveListener(EndTrack);
     }
 
-    private void StartTrack(GameSettings gameSettings)
+    private void StartTrack(GameSettingsInfo gameSettings)
     {
         track.volume = gameSettings.MusicVolume / 100.0f;
         track.Play();

--- a/Assets/Code/Data/GameEventCenter.cs
+++ b/Assets/Code/Data/GameEventCenter.cs
@@ -12,7 +12,7 @@ public static class GameEventCenter
     public static GameEvent<RecordedScore> scoreChange                = new GameEvent<RecordedScore>();
     public static GameEvent<PaddleZoneIntersectInfo> zoneIntersection = new GameEvent<PaddleZoneIntersectInfo>();
 
-    public static GameEvent<GameSettings>     startNewGame        = new GameEvent<GameSettings>();
+    public static GameEvent<GameSettingsInfo>     startNewGame        = new GameEvent<GameSettingsInfo>();
     public static GameEvent<RecordedScore>    pauseGame           = new GameEvent<RecordedScore>();
     public static GameEvent<string>           resumeGame          = new GameEvent<string>();
     public static GameEvent<string>           gotoMainMenu        = new GameEvent<string>();

--- a/Assets/Code/Data/GameSettingInfo.cs
+++ b/Assets/Code/Data/GameSettingInfo.cs
@@ -1,29 +1,29 @@
 ﻿using UnityEngine;
 
 
-public class GameSettings
+public class GameSettingsInfo
 {
-    public int NumberOfGoals   { get; private set; }
-    public int DifficultyLevel { get; private set; }
-    public int SoundVolume     { get; private set; }
-    public int MusicVolume     { get; private set; }
+    public int   NumberOfGoals   { get; private set; }
+    public float DifficultyLevel { get; private set; }
+    public float SoundVolume     { get; private set; }
+    public float MusicVolume     { get; private set; }
     public override string ToString()
     {
         return $"NumberOfGoals is {NumberOfGoals}, and difficulty is {DifficultyLevel}%, " +
                $"SoundVolume is {SoundVolume}%, and MusicVolume is {MusicVolume}%";
     }
 
-    public GameSettings(int numberOfGoals, int difficultyLevel, int soundVolume, int musicVolume)
+    public GameSettingsInfo(int numberOfGoals, int difficultyPercent, int soundVolumePercent, int musicVolumePercent)
     {
-        if (ValidPositiveInteger(numberOfGoals) &&
-            ValidatePercentage(difficultyLevel) &&
-            ValidatePercentage(soundVolume)     &&
-            ValidatePercentage(musicVolume))
+        if (ValidPositiveInteger(numberOfGoals)    &&
+            ValidatePercentage(difficultyPercent)  &&
+            ValidatePercentage(soundVolumePercent) &&
+            ValidatePercentage(musicVolumePercent))
         {
             NumberOfGoals   = numberOfGoals;
-            DifficultyLevel = difficultyLevel;
-            SoundVolume     = soundVolume;
-            MusicVolume     = musicVolume;
+            DifficultyLevel = MathUtils.PercentToRatio(difficultyPercent);
+            SoundVolume     = MathUtils.PercentToRatio(soundVolumePercent);
+            MusicVolume     = MathUtils.PercentToRatio(musicVolumePercent);
         }
     }
 
@@ -31,16 +31,16 @@ public class GameSettings
     {
         if (value < 0)
         {
-            Debug.LogError($"`{nameof(value)}` must be greater than 0");
+            Debug.LogError($"`{nameof(value)}` must be an integer greater than 0, recieved {value} instead");
             return false;
         }
         return true;
     }
     private bool ValidatePercentage(int value)
     {
-        if (value < 0 || value > 100)
+        if (!MathUtils.IsWithinRange(value, 0, 100))
         {
-            Debug.LogError($"`{nameof(value)}` must be between 0 and 100%");
+            Debug.LogError($"`{nameof(value)}` must be given as an integer percentage between 0 and 100, recieved {value} instead");
             return false;
         }
         return true;

--- a/Assets/Code/Tools/MathUtils.cs
+++ b/Assets/Code/Tools/MathUtils.cs
@@ -2,8 +2,22 @@
 using UnityEngine;
 
 
+// note: methods, where it makes sense to, logerrors (ie in conversion methods, or other methods
+// that wouldn't be used on a frame by frame basis.
+// otherwise the methods make appropriate assumptions about input, stated in their corresponding comments
 public static class MathUtils
 {
+    // assuming given value is between 0, 100, convert to a ratio between 0.00 and 1.00
+    public static float PercentToRatio(float percent)
+    {
+        return Mathf.Approximately(percent, 0.00f)? 0.00f : percent / 100.00f;
+    }
+    // assuming given value is between 0, 100, convert to a ratio between 0.00 and 1.00
+    public static float RatioToPercent(float ratio)
+    {
+        return ratio * 100.00f;
+    }
+
     public static float RandomSign()
     {
         return Random.Range(0, 2) == 0? 1.0f : -1.0f;
@@ -19,11 +33,11 @@ public static class MathUtils
     {
         return startA <= endB && startB <= endA;
     }
+
     public static bool IsInteger(float value)
     {
         return Mathf.Approximately(value - Mathf.Round(value), 0);
     }
-
     public static bool IsAllInteger(params string[] values)
     {
         foreach (string value in values)
@@ -35,7 +49,6 @@ public static class MathUtils
         }
         return true;
     }
-
     public static bool IsAllFloat(params string[] values)
     {
         foreach (string value in values)

--- a/Assets/Prefabs/AiPaddle.prefab
+++ b/Assets/Prefabs/AiPaddle.prefab
@@ -12,13 +12,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d08e6e93e462d54c831f2f23873b9fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  paddleSpeedAtMaxDifficulty: 37.5
-  responseTimeAtMaxDifficulty: 0.325
-  minVerticalDistanceBeforeMoving: 0.025
-  initialTimeDelayAfterReset: 0.125
+  paddleSpeedAtMinDifficulty: 35
+  paddleSpeedAtMaxDifficulty: 70
+  responseTimeAtMinDifficulty: 0.45
+  responseTimeAtMaxDifficulty: 0.2
+  minVerticalDistanceBeforeMoving: 0.015
+  initialTimeDelayAfterReset: 0.15
   layersUsedWhenPredictingTrajectory:
     serializedVersion: 2
     m_Bits: 256
+  difficultyRatio: 0
 --- !u!1001 &4236686123768063564
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -274,10 +274,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1728929205, guid: c8dbfa0f129a8e84e951632cab7d6425, type: 3}
-      propertyPath: initialDirection.x
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 7617027791629370971, guid: c8dbfa0f129a8e84e951632cab7d6425,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1358,14 +1354,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 256875173, guid: 0173095caa3a77b4ebfecb9bd4d161d9, type: 3}
-      propertyPath: paddleSpeedAtMaxDifficulty
-      value: 70
-      objectReference: {fileID: 0}
-    - target: {fileID: 256875173, guid: 0173095caa3a77b4ebfecb9bd4d161d9, type: 3}
-      propertyPath: ResponseTimeAtMinDifficulty
-      value: 0.5
-      objectReference: {fileID: 0}
     - target: {fileID: 4898979997282198361, guid: 0173095caa3a77b4ebfecb9bd4d161d9,
         type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
# Convert all slider value percentages as ratios between inspector-assigned min/max values

## The problem
The issue this PR addresses the issue that when the difficulty, for example, is at lower (ie 20%) and higher difficulties (ie 80%) - the user experience is just ridiculous, as it doesn't make sense to have a paddle speed close to zero, for example. That's not just easy, its just useless.

## The solution
To change this, all those values are converted to float ratios with an inspector-assigned lower/upper bounds.

For example, we now have the fields `PADDLE_SPEED_AT_MIN_DIFFICULTY` `PADDLE_SPEED_AT_MAX_DIFFICULTY` assigned in the `AiPaddle`'s inspector panel, and everything is treated as a ratio corresponding to the percent chosen in the main menu, which corresponds to a value within the min and max range described above.

Similarly for the other slider values as well.

#### Example walkthrough to illustrate what's changed
So when the user adjusts the startmenu slider to a percentage difficulty/volume/etc (integer between zero and a 100), those values are set/validated/converted to ratios in the `GameSettingsInfo` object that is sent to the `Game` scene on the triggering of the `StartNewGame` event.

Then, those settings (now all accessed strictly as ratios) are received by the appropriate scene objects and set accordingly.

Treating everything as ratios past the main menu significantly simplifies calculations as well, as no conversions have to happen anywhere else in the program - unlike before.