### PR TITLE
Replace tag literals with a custom tag selection attributes in inspector

### DIFF
--- a/Assets/Code/Controllers/IngameMenuController.cs
+++ b/Assets/Code/Controllers/IngameMenuController.cs
@@ -16,13 +16,16 @@ public class IngameMenuController : MonoBehaviour
     private List<Button> buttonsToHideWhenActive;
     private List<TMPro.TextMeshProUGUI> labelsToHideWhenActive;
     private List<SpriteRenderer> spritesToHideWhenActive;
+    [TagSelector] [SerializeField] private string[] tagsOfButtonsToHideOnMenuOpen = new string[] { };
+    [TagSelector] [SerializeField] private string[] tagsOfLabelsToHideOnMenuOpen  = new string[] { };
+    [TagSelector] [SerializeField] private string[] tagsOfSpritesToHideOnMenuOpen = new string[] { };
 
     void Awake()
     {
         ingameMenu.SetActive(false);  // ensures that the fetched objects are OUTSIDE the ingame menu
-        buttonsToHideWhenActive = GameObjectUtils.FindAllObjectsWithTags<Button>("Button");
-        labelsToHideWhenActive  = GameObjectUtils.FindAllObjectsWithTags<TMPro.TextMeshProUGUI>("Label");
-        spritesToHideWhenActive = GameObjectUtils.FindAllObjectsWithTags<SpriteRenderer>("Ball", "Paddle", "GuidingLine");
+        buttonsToHideWhenActive = GameObjectUtils.FindAllObjectsWithTags<Button>(tagsOfButtonsToHideOnMenuOpen);
+        labelsToHideWhenActive  = GameObjectUtils.FindAllObjectsWithTags<TMPro.TextMeshProUGUI>(tagsOfLabelsToHideOnMenuOpen);
+        spritesToHideWhenActive = GameObjectUtils.FindAllObjectsWithTags<SpriteRenderer>(tagsOfSpritesToHideOnMenuOpen);
 
         GameEventCenter.pauseGame.AddListener(OpenAsPauseMenu);
         GameEventCenter.winningScoreReached.AddListener(OpenAsEndGameMenu);

--- a/Assets/Code/Controllers/MainMenuController.cs
+++ b/Assets/Code/Controllers/MainMenuController.cs
@@ -10,14 +10,16 @@ public class MainMenuController : MonoBehaviour
     [SerializeField] private Button aboutButton    = default;
     [SerializeField] private Button quitButton     = default;
     [SerializeField] private MainMenuPanelController mainMenuPanelController = default;
-
+    
     private List<Button> buttonsToHideWhenPanelIsOpen;
-    private List<TMPro.TextMeshProUGUI> labelToHideWhenPanelIsOpen;
-
+    private List<TMPro.TextMeshProUGUI> labelsToHideWhenPanelIsOpen;
+    [TagSelector] [SerializeField] private string[] tagsOfButtonsToHideWhenPanelIsOpen = new string[] { };
+    [TagSelector] [SerializeField] private string[] tagsOfLabelsToHideWhenPanelIsOpen  = new string[] { };
+    
     void Awake()
     {
-        buttonsToHideWhenPanelIsOpen = GameObjectUtils.FindAllObjectsWithTags<Button>("Button");
-        labelToHideWhenPanelIsOpen  = GameObjectUtils.FindAllObjectsWithTags<TMPro.TextMeshProUGUI>("Subtitle");
+        buttonsToHideWhenPanelIsOpen = GameObjectUtils.FindAllObjectsWithTags<Button>(tagsOfButtonsToHideWhenPanelIsOpen);
+        labelsToHideWhenPanelIsOpen  = GameObjectUtils.FindAllObjectsWithTags<TMPro.TextMeshProUGUI>(tagsOfLabelsToHideWhenPanelIsOpen);
 
         mainMenuPanelController.SetActionOnStartPressed(() => LoadGame());
         mainMenuPanelController.SetActionOnPanelOpen(()    => ToggleMenuVisibility(true));
@@ -58,9 +60,9 @@ public class MainMenuController : MonoBehaviour
         {
             GameObjectUtils.SetButtonVisibility(buttonsToHideWhenPanelIsOpen[i], hideBackground);
         }
-        for (int i = 0; i < labelToHideWhenPanelIsOpen.Count; i++)
+        for (int i = 0; i < labelsToHideWhenPanelIsOpen.Count; i++)
         {
-            GameObjectUtils.SetLabelVisibility(labelToHideWhenPanelIsOpen[i], hideBackground);
+            GameObjectUtils.SetLabelVisibility(labelsToHideWhenPanelIsOpen[i], hideBackground);
         }
         #if UNITY_WEBGL
             GameObjectUtils.SetButtonActiveAndEnabled(quitButton, false);

--- a/Assets/Code/Editor/TagSelectorPropertyDrawer.cs
+++ b/Assets/Code/Editor/TagSelectorPropertyDrawer.cs
@@ -1,0 +1,49 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System;
+
+
+// adopted from: http://www.brechtos.com/tagselectorattribute/
+[CustomPropertyDrawer(typeof(TagSelectorAttribute))]
+public class TagSelectorPropertyDrawer : PropertyDrawer
+{
+    private string[] tags;
+    private const string EMPTY_TAG_NAME = "<No Tag>";
+
+    private void UpdateTags()
+    {
+        tags = CollectionUtils.PrependToArray(EMPTY_TAG_NAME, UnityEditorInternal.InternalEditorUtility.tags);
+    }
+
+    private int IndexOfTag(string tag)
+    {
+        return tag == "" ? 0 : Array.IndexOf(tags, tag, 1);
+    }
+
+    // get the latest tags from editor and display them in a dropdown with our drawer getting the selected tag
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        if (property.propertyType == SerializedPropertyType.String)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            var attrib = this.attribute as TagSelectorAttribute;
+            if (attrib.UseDefaultTagFieldDrawer)
+            {
+                property.stringValue = EditorGUI.TagField(position, label, property.stringValue);
+            }
+            else
+            {
+                UpdateTags();
+                int selectedIndex = EditorGUI.Popup(position, label.text, IndexOfTag(property.stringValue), displayedOptions: tags);
+                property.stringValue = selectedIndex >= 1? tags[selectedIndex] : "";
+            }
+
+            EditorGUI.EndProperty();
+        }
+        else
+        {
+            EditorGUI.PropertyField(position, property, label);
+        }
+    }
+}

--- a/Assets/Code/Editor/TagSelectorPropertyDrawer.cs.meta
+++ b/Assets/Code/Editor/TagSelectorPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6c2408a00ee2854c9b545edeafb55bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/TagSelectorAttribute.cs
+++ b/Assets/Code/TagSelectorAttribute.cs
@@ -1,0 +1,8 @@
+﻿using UnityEngine;
+
+
+// see `Editor/TagSelectorPropertyDrawer` for usage
+public class TagSelectorAttribute : PropertyAttribute
+{
+    public bool UseDefaultTagFieldDrawer = false;
+}

--- a/Assets/Code/TagSelectorAttribute.cs.meta
+++ b/Assets/Code/TagSelectorAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: afdeeeeeb86436848bb5c0d66bbf616b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/Tools/CollectionUtils.cs
+++ b/Assets/Code/Tools/CollectionUtils.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+
+public static class CollectionUtils
+{
+    public static string[] PrependToArray(string value, string[] source)
+    {
+        string[] newArray = new string[source.Length + 1];
+        newArray[0] = value;
+        Array.Copy(source, 0, newArray, 1, source.Length);
+        return newArray;
+    }
+}

--- a/Assets/Code/Tools/CollectionUtils.cs.meta
+++ b/Assets/Code/Tools/CollectionUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fadc495ecf2131c4b8ac846946f024dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -943,6 +943,14 @@ MonoBehaviour:
   mainMenuButton: {fileID: 2111221937}
   restartButton: {fileID: 2111221936}
   quitButton: {fileID: 2111221935}
+  tagsOfButtonsToHideOnMenuOpen:
+  - Button
+  tagsOfLabelsToHideOnMenuOpen:
+  - Label
+  tagsOfSpritesToHideOnMenuOpen:
+  - Ball
+  - Paddle
+  - GuidingLine
 --- !u!1001 &1891626405
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -389,6 +389,10 @@ MonoBehaviour:
   aboutButton: {fileID: 149932780}
   quitButton: {fileID: 2485890}
   mainMenuPanelController: {fileID: 1678574996}
+  tagsOfButtonsToHideWhenPanelIsOpen:
+  - Button
+  tagsOfLabelsToHideWhenPanelIsOpen:
+  - Subtitle
 --- !u!1001 &930906539
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# Add tag selection fields in inspector

Added ability to select tags in inspector, replacing much of the cases where literals were previously used (mainly in the `main` and `ingame` menu-controllers).

This makes things easier, cause we don't have to worry about the tags becoming quietly invalid like they would with string literals - instead it uses the unity editor's already existing tags list.

For example:
![image](https://user-images.githubusercontent.com/8084757/80159870-f0c56d80-8580-11ea-9838-e3a765fe6159.png)
