### PR TITLE
Migrate to major new release (unity 2020.1.0f1)

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,12 +1,13 @@
 {
   "dependencies": {
-    "com.unity.2d.pixel-perfect": "2.0.4",
+    "com.unity.2d.pixel-perfect": "3.0.2",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ext.nunit": "1.0.0",
+    "com.unity.ide.visualstudio": "2.0.2",
     "com.unity.ide.vscode": "1.2.1",
     "com.unity.test-framework": "1.1.14",
-    "com.unity.textmeshpro": "2.0.1",
-    "com.unity.timeline": "1.4.0",
+    "com.unity.textmeshpro": "3.0.0",
+    "com.unity.timeline": "1.4.1",
     "com.unity.ugui": "1.0.0",
     "com.unity.vectorgraphics": "2.0.0-preview.12",
     "com.unity.modules.ai": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.2d.pixel-perfect": {
-      "version": "2.0.4",
+      "version": "3.0.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -15,6 +15,13 @@
     },
     "com.unity.ext.nunit": {
       "version": "1.0.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.ide.visualstudio": {
+      "version": "2.0.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -39,7 +46,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.textmeshpro": {
-      "version": "2.0.1",
+      "version": "3.0.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -48,7 +55,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.timeline": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -210,6 +217,18 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.uielementsnative": "1.0.0"
+      }
+    },
+    "com.unity.modules.uielementsnative": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.4.5f1
-m_EditorVersionWithRevision: 2019.4.5f1 (81610f64359c)
+m_EditorVersion: 2020.1.0f1
+m_EditorVersionWithRevision: 2020.1.0f1 (2ab9c4179772)

--- a/ProjectSettings/VersionControlSettings.asset
+++ b/ProjectSettings/VersionControlSettings.asset
@@ -1,0 +1,8 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!890905787 &1
+VersionControlSettings:
+  m_ObjectHideFlags: 0
+  m_Mode: Visible Meta Files
+  m_CollabEditorSettings:
+    inProgressEnabled: 1

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!162 &1
+EditorUserSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 4
+  m_ConfigSettings:
+    UnityRemoteCompression:
+      value: 337f73
+      flags: 0
+    vcSharedLogLevel:
+      value: 0d5e400f0650
+      flags: 0
+  m_VCAutomaticAdd: 1
+  m_VCDebugCom: 0
+  m_VCDebugCmd: 0
+  m_VCDebugOut: 0
+  m_SemanticMergeMode: 2
+  m_VCShowFailedCheckout: 1
+  m_VCOverwriteFailedCheckoutAssets: 1
+  m_VCAllowAsyncUpdate: 0
+  m_AssetPipelineMode: 0
+  m_CacheServerMode: 0
+  m_CacheServers: []


### PR DESCRIPTION
# Migrate to major new release (unity 2020.1.0f1)
This migration went smoother than expected.
All packages and builtins up to date, and settings updated to reflect the changes.

No regressions were found in upgrading, thankfully!