### PR TITLE
Project Settings: Remove unused sprite and testing related packages

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,14 +1,9 @@
 {
   "dependencies": {
-    "com.unity.2d.pixel-perfect": "4.0.1",
     "com.unity.2d.sprite": "1.0.0",
-    "com.unity.ext.nunit": "1.0.6",
     "com.unity.ide.visualstudio": "2.0.5",
-    "com.unity.test-framework": "1.1.20",
     "com.unity.textmeshpro": "3.0.3",
-    "com.unity.timeline": "1.4.5",
     "com.unity.ugui": "1.0.0",
-    "com.unity.vectorgraphics": "2.0.0-preview.13",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,41 +1,16 @@
 {
   "dependencies": {
-    "com.unity.2d.pixel-perfect": {
-      "version": "4.0.1",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.2d.sprite": {
       "version": "1.0.0",
       "depth": 0,
       "source": "builtin",
       "dependencies": {}
     },
-    "com.unity.ext.nunit": {
-      "version": "1.0.6",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.ide.visualstudio": {
       "version": "2.0.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.test-framework": {
-      "version": "1.1.20",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ext.nunit": "1.0.6",
-        "com.unity.modules.imgui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
-      },
       "url": "https://packages.unity.com"
     },
     "com.unity.textmeshpro": {
@@ -47,18 +22,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.timeline": {
-      "version": "1.4.5",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.modules.director": "1.0.0",
-        "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.audio": "1.0.0",
-        "com.unity.modules.particlesystem": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.ugui": {
       "version": "1.0.0",
       "depth": 0,
@@ -67,16 +30,6 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0"
       }
-    },
-    "com.unity.vectorgraphics": {
-      "version": "2.0.0-preview.13",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.2d.sprite": "1.0.0",
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
     },
     "com.unity.modules.ai": {
       "version": "1.0.0",


### PR DESCRIPTION
# Remove unused sprite and testing related packages
Removes unused packages - vector graphics, pixel-perfect rendering, test frameworks, and timelines - thus dramatically improving the Unity project's load and import times.